### PR TITLE
Correct Top URL

### DIFF
--- a/pipeline/api/cloud.py
+++ b/pipeline/api/cloud.py
@@ -139,7 +139,7 @@ class PipelineCloud:
             file_id=file_schema.id,
         )
 
-        request_result = self._post("/v2/functions/", function_create_schema.dict())
+        request_result = self._post("/v2/functions", function_create_schema.dict())
 
         return FunctionGet.parse_obj(request_result)
 


### PR DESCRIPTION
The trailing slash results in a redirect response, but the redirect doesn't include the `Authorization` header in production so causes 403 errors.

(Most Top URLs do not end in a slash; `POST /v2/files/` is one exception I know of, there may be others)