### PR TITLE
Set Function's local ID on creation from remote schema

### DIFF
--- a/examples/basic_maths/basic_maths.py
+++ b/examples/basic_maths/basic_maths.py
@@ -3,7 +3,7 @@ from pipeline import Pipeline, Variable, pipeline_function
 
 @pipeline_function
 def square(a: float) -> float:
-    return a ** 2
+    return a**2
 
 
 @pipeline_function

--- a/pipeline/objects/function.py
+++ b/pipeline/objects/function.py
@@ -57,5 +57,6 @@ class Function:
         # TODO: Add loading from files instead
         assert isinstance(schema, FunctionGet)
         function: Function = hex_to_python_object(schema.hex_file.data)
+        function.local_id = schema.id
         # print(function.function(5.0))
         return function

--- a/tests/test_pipeline_main.py
+++ b/tests/test_pipeline_main.py
@@ -28,7 +28,7 @@ def test_basic_pipeline():
 
     @pipeline_function
     def square(f_1: float) -> float:
-        return f_1 ** 2
+        return f_1**2
 
     with Pipeline("test") as my_pipeline:
         in_1 = Variable(float, is_input=True)


### PR DESCRIPTION
Uploading a Pipeline looks like:

1. [Upload the `Function` objects](https://github.com/mystic-ai/pipeline/blob/ca7d5072a5827935be8cbfec24129feeef71a2ff/pipeline/api/cloud.py#L165-L168).
2. [Replace the `local_id` of each `Function` object](https://github.com/mystic-ai/pipeline/blob/ca7d5072a5827935be8cbfec24129feeef71a2ff/pipeline/api/cloud.py#L169-L170) with the remote ID.
3. Upload the some other objects (`Model` and `Variable`).
4. Create schemas from the remaining objects ([`GraphNode`](https://github.com/mystic-ai/pipeline/blob/ca7d5072a5827935be8cbfec24129feeef71a2ff/pipeline/api/cloud.py#L190-L192) and output `Variable`)
4. Create and push a `Pipeline` schema.

I think there is a bug when resurrecting a Pipeline. The graph nodes will contain the remote `Function` IDs thanks to step 2 above, however the [`Function` objects resurrected from the schemas](https://github.com/mystic-ai/pipeline/blob/ca7d5072a5827935be8cbfec24129feeef71a2ff/pipeline/objects/graph.py#L148) will not have the remote ID as they are uploaded before the replacement. This causes the [function search](https://github.com/mystic-ai/pipeline/blob/ca7d5072a5827935be8cbfec24129feeef71a2ff/pipeline/objects/graph.py#L174-L177) to fail because `_node.function` is a remote ID whereas `_func.local_id` is a local one.

This PR is one possible fix: when resurrecting a `Function` from a schema, override the deserialised `local_id` with the (remote!) ID included in the schema.