### PR TITLE
Support run result previews

### DIFF
--- a/examples/api_pipeline_run.py
+++ b/examples/api_pipeline_run.py
@@ -1,3 +1,5 @@
+import json
+
 from dotenv import load_dotenv
 
 from pipeline import Pipeline, PipelineCloud, Variable, pipeline_function
@@ -24,4 +26,10 @@ with Pipeline("AddLol") as builder:
 test_pipeline = Pipeline.get_pipeline("AddLol")
 upload_output = api.upload_pipeline(test_pipeline)
 
-print(api.run_pipeline(upload_output, "Hi I like to")["run_state"])
+run_result = api.run_pipeline(upload_output, "Hi I like to")
+print("Run state:", run_result["run_state"])
+try:
+    result_preview = json.loads(run_result["result_preview"])
+except (TypeError, json.JSONDecodeError):
+    result_preview = "unavailable"
+print("Run result:", result_preview)

--- a/pipeline/schemas/run.py
+++ b/pipeline/schemas/run.py
@@ -78,6 +78,8 @@ class RunGet(BaseModel):
     data: DataGet
     blocking: Optional[bool] = False
     result: Optional[FileGet]
+    #: JSON-serialised runnable return value, if available
+    result_preview: Optional[str]
     error: Optional[RunError]
 
     class Config:


### PR DESCRIPTION
Run execution now provides an optional 'preview' as a JSON encoding of the object returned by the executed runnable. This PR:

- Adds `RunGet.result_preview` schema field to support receiving that preview.
- Modifies one of the examples to show the preview.
