### PR TITLE
Require `total` parameter when constructing Paginated

### DIFF
--- a/pipeline/schemas/pagination.py
+++ b/pipeline/schemas/pagination.py
@@ -6,20 +6,29 @@ DataType = TypeVar("DataType")
 
 
 class PaginationDetails(BaseModel):
+    """Query parameters for requesting paginated resource lists."""
+
+    #: Index of resource items to begin paginating from
     skip: int
+    #: Maximum number of resources to return
     limit: int
 
 
 class Paginated(GenericModel, Generic[DataType]):
+    """Response for paginated resource lists."""
 
+    #: Index of resource items to begin paginating from
     skip: int
+    #: Maximum number of resources the `data` field will contain
     limit: int
+    #: Total number of resources available for pagination
     total: int
+    #: Resource data
     data: List[DataType]
 
     @classmethod
-    def of(cls, item_list: List[DataType], details: PaginationDetails):
+    def of(cls, item_list: List[DataType], details: PaginationDetails, total: int):
 
         return Paginated(
-            skip=details.skip, limit=details.limit, total=len(item_list), data=item_list
+            skip=details.skip, limit=details.limit, total=total, data=item_list
         )


### PR DESCRIPTION
Currently `Paginated.of` computes `Paginated.total` by counting the number of items it receives, but `Paginated.total` should represent the total number of objects that are available for pagination, rather than the number currently being returned.

This PR modifies `Paginated.of` to _require_ a `total: int` parameter, which is used to populate the `Paginated.total` field.

Towards [NA-389](https://neuro-ai.atlassian.net/browse/NA-389).