### PR TITLE
PipelineCloud allows token on creation and auto-auth if token is defined

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
     hooks:
     -   id: flake8
 -   repo: https://github.com/psf/black
-    rev: 21.12b0
+    rev: 22.1.0
     hooks:
     -   id: black
 -   repo: https://github.com/PyCQA/isort

--- a/pipeline/api/cloud.py
+++ b/pipeline/api/cloud.py
@@ -34,7 +34,7 @@ class PipelineCloud:
             self.authenticate()
         else:
             print(
-                "No token set, please set one and invoke ",
+                "No token set, please set one and invoke",
                 "PipelineCloud.authenticate() method",
             )
 

--- a/pipeline/api/cloud.py
+++ b/pipeline/api/cloud.py
@@ -34,8 +34,8 @@ class PipelineCloud:
             self.authenticate()
         else:
             print(
-                "No token set, please set one and invoke \
-                     PipelineCloud.authenticate() method"
+                "No token set, please set one and invoke ",
+                "PipelineCloud.authenticate() method",
             )
 
     def authenticate(self, token: str = None):

--- a/pipeline/api/cloud.py
+++ b/pipeline/api/cloud.py
@@ -30,7 +30,13 @@ class PipelineCloud:
     def __init__(self, url: str = None, token: str = None) -> None:
         self.token = token or os.getenv("PIPELINE_API_TOKEN")
         self.url = url or os.getenv("PIPELINE_API_URL", "https://api.pipeline.ai")
-        self.authenticate()
+        if self.token is not None:
+            self.authenticate()
+        else:
+            print(
+                "No token set, please set one and invoque \
+                     PipelineCloud.authenticate() method"
+            )
 
     def authenticate(self, token: str = None):
         """

--- a/pipeline/api/cloud.py
+++ b/pipeline/api/cloud.py
@@ -10,8 +10,8 @@ import requests
 from requests_toolbelt.multipart import encoder
 from tqdm import tqdm
 
-from pipeline.schemas.file import FileGet
 from pipeline.schemas.data import DataGet
+from pipeline.schemas.file import FileGet
 from pipeline.schemas.function import FunctionCreate, FunctionGet
 from pipeline.schemas.model import ModelCreate, ModelGet
 from pipeline.schemas.pipeline import PipelineCreate, PipelineGet, PipelineVariableGet
@@ -27,9 +27,10 @@ class PipelineCloud:
     token: Optional[str]
     url: Optional[str]
 
-    def __init__(self, url: str = None) -> None:
-        self.token = os.getenv("PIPELINE_API_TOKEN")
+    def __init__(self, url: str = None, token: str = None) -> None:
+        self.token = token or os.getenv("PIPELINE_API_TOKEN")
         self.url = url or os.getenv("PIPELINE_API_URL", "https://api.pipeline.ai")
+        self.authenticate()
 
     def authenticate(self, token: str = None):
         """

--- a/pipeline/api/cloud.py
+++ b/pipeline/api/cloud.py
@@ -34,7 +34,7 @@ class PipelineCloud:
             self.authenticate()
         else:
             print(
-                "No token set, please set one and invoque \
+                "No token set, please set one and invoke \
                      PipelineCloud.authenticate() method"
             )
 


### PR DESCRIPTION
Introducing changes based on the enhancement request on [issue 66](https://github.com/mystic-ai/pipeline/issues/66)

PipelineCloud now can receive a user token directly on instantiation and if it is provided either as an arg or env variable the authenticate method is immediately executed. Otherwise it must be done manually once user defined their user token

