### PR TITLE
add compute type field to run create schema

### DIFF
--- a/examples/api_pipeline_run.py
+++ b/examples/api_pipeline_run.py
@@ -3,7 +3,6 @@ import json
 from pipeline import Pipeline, PipelineCloud, Variable, pipeline_function
 
 api = PipelineCloud()
-api.authenticate()
 
 
 @pipeline_function

--- a/examples/huggingface/gpt-j-6b.py
+++ b/examples/huggingface/gpt-j-6b.py
@@ -131,7 +131,6 @@ class TransformersModelForCausalLM:
 
 
 api = PipelineCloud()
-api.authenticate()
 
 with Pipeline("GPT-J-6B") as builder:
     input_str = Variable(str, is_input=True)

--- a/examples/huggingface/gpt-neo-upload.py
+++ b/examples/huggingface/gpt-neo-upload.py
@@ -44,7 +44,6 @@ class TransformersModelForCausalLM:
 # load_dotenv("hidden.env")
 
 api = PipelineCloud()
-api.authenticate()
 
 with Pipeline("HF pipeline") as builder:
     input_str = Variable(str, is_input=True)

--- a/pipeline/schemas/run.py
+++ b/pipeline/schemas/run.py
@@ -33,12 +33,18 @@ class RunError(Enum):
     PIPELINE_FAULT = "pipeline_fault"
 
 
+class ComputeType(Enum):
+    cpu = "cpu"
+    gpu = "gpu"
+
+
 class RunCreate(BaseModel):
     pipeline_id: Optional[str]
     function_id: Optional[str]
     data: Optional[Any]
     data_id: Optional[str]
     blocking: Optional[bool] = False
+    compute_type: ComputeType = ComputeType.gpu
 
     @root_validator
     def pipeline_data_val(cls, values):

--- a/pipeline/schemas/run.py
+++ b/pipeline/schemas/run.py
@@ -81,6 +81,7 @@ class RunGet(BaseModel):
     started_at: Optional[datetime.datetime]
     ended_at: Optional[datetime.datetime]
     run_state: RunState
+    resource_type: Optional[str]
     compute_time_ms: Optional[int]
     runnable: Union[FunctionGet, PipelineGet]
     data: DataGet
@@ -97,7 +98,6 @@ class RunGet(BaseModel):
 class RunGetDetailed(RunGet):
     runnable: Union[FunctionGetDetailed, PipelineGetDetailed]
     n_resources: int
-    resource_type: Optional[str]
     region: str
     tags: List[TagGet] = []
     inputs: List[RunIOGet] = []

--- a/pipeline/schemas/run.py
+++ b/pipeline/schemas/run.py
@@ -45,6 +45,7 @@ class RunCreate(BaseModel):
     data: Optional[Any]
     data_id: Optional[str]
     blocking: Optional[bool] = False
+    # By default a Run will require GPU resources
     compute_type: ComputeType = ComputeType.gpu
 
     @root_validator

--- a/pipeline/schemas/run.py
+++ b/pipeline/schemas/run.py
@@ -33,9 +33,10 @@ class RunError(Enum):
     PIPELINE_FAULT = "pipeline_fault"
 
 
-class ComputeType(Enum):
-    cpu = "cpu"
-    gpu = "gpu"
+# https://github.com/samuelcolvin/pydantic/issues/2278
+class ComputeType(str, Enum):
+    cpu: str = "cpu"
+    gpu: str = "gpu"
 
 
 class RunCreate(BaseModel):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pipeline-ai"
-version = "0.0.25"
+version = "0.0.26"
 description = "Pipelines for machine learning workloads."
 authors = ["Paul Hetherington <ph@mystic.ai>", "Alex Pearwin <alex@mystic.ai>", "Maximiliano Schulkin <max@mystic.ai>", "Neil Wang <neil@mystic.ai>"]
 packages = [


### PR DESCRIPTION
[NA-511](https://neuro-ai.atlassian.net/browse/NA-511)

This PR is part of a change spanning multiple services aiming to have a consistent designation of workloads to the correct machines

This PR aims at adding a default run compute type - GPU - to be sent to our internal systems where it will be properly allocated to a resource