### PR TITLE
create brief schema, keep pipelineGet as is

### DIFF
--- a/pipeline/schemas/pipeline.py
+++ b/pipeline/schemas/pipeline.py
@@ -41,9 +41,15 @@ class PipelineVariableGet(BaseModel):
         return values
 
 
-class PipelineGet(RunnableGet):
+class PipelineGetBrief(RunnableGet):
     id: str
     name: str
+    deployed: bool = False
+    tags: List[str] = []
+    description: str = ""
+
+
+class PipelineGet(PipelineGetBrief):
     type: RunnableType = Field(RunnableType.pipeline, const=True)
     variables: List[PipelineVariableGet]
     functions: List[FunctionGet]

--- a/pipeline/schemas/pipeline.py
+++ b/pipeline/schemas/pipeline.py
@@ -41,7 +41,7 @@ class PipelineVariableGet(BaseModel):
         return values
 
 
-class PipelineGetBrief(RunnableGet):
+class PipelineGetBrief(BaseModel):
     id: str
     name: str
     deployed: bool = False
@@ -49,7 +49,7 @@ class PipelineGetBrief(RunnableGet):
     description: str = ""
 
 
-class PipelineGet(PipelineGetBrief):
+class PipelineGet(PipelineGetBrief, RunnableGet):
     type: RunnableType = Field(RunnableType.pipeline, const=True)
     variables: List[PipelineVariableGet]
     functions: List[FunctionGet]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pipeline-ai"
-version = "0.0.27"
+version = "0.0.28"
 description = "Pipelines for machine learning workloads."
 authors = ["Paul Hetherington <ph@mystic.ai>", "Alex Pearwin <alex@mystic.ai>", "Maximiliano Schulkin <max@mystic.ai>", "Neil Wang <neil@mystic.ai>"]
 packages = [


### PR DESCRIPTION
This PR aims to create a Brief schema for PipelineGet  which holds the most basic information for pipelines, this approach was preferred to preserve PipelineGet schema with its original fields, thus avoiding possible unforeseen impact on other services.