### PR TITLE
Add timestamp fields to Token schema

### DIFF
--- a/pipeline/schemas/token.py
+++ b/pipeline/schemas/token.py
@@ -14,13 +14,17 @@ class TokenGet(BaseModel):
     value: str
     #: Token value, used when authenticating with the API
     name: str
-    # Timestamp value of expiry
+    #: Timestamp value of creation
+    created_at: datetime
+    #: Timestamp value of last update
+    updated_at: datetime
+    #: Timestamp value of expiry
     expires_at: Optional[datetime]
-    # Timestamp value of last usage
+    #: Timestamp value of last usage
     last_used: Optional[datetime]
-    # If token is active (set by user and it's before its expiry date)
+    #: If token is active (set by user and it's before its expiry date)
     is_active: bool
-    # Arbitrarily set user flag for token validity
+    #: Arbitrarily set user flag for token validity
     is_enabled: bool
 
 

--- a/pipeline/schemas/token.py
+++ b/pipeline/schemas/token.py
@@ -31,10 +31,12 @@ class TokenGet(BaseModel):
 class TokenCreate(BaseModel):
     """Model for creating token"""
 
-    # Arbitrary name to be assigned to token
+    #: Arbitrary name to be assigned to token
     name: Optional[str]
-    # Role name which assigns permissions
+    #: Role name which assigns permissions
     type: str
+    #: Timestamp value of future expiry
+    expires_at: Optional[datetime]
 
 
 class TokenPatch(Patchable):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pipeline-ai"
-version = "0.0.26"
+version = "0.0.27"
 description = "Pipelines for machine learning workloads."
 authors = ["Paul Hetherington <ph@mystic.ai>", "Alex Pearwin <alex@mystic.ai>", "Maximiliano Schulkin <max@mystic.ai>", "Neil Wang <neil@mystic.ai>"]
 packages = [


### PR DESCRIPTION
Partially addresses [NA-247](https://neuro-ai.atlassian.net/browse/NA-247) by:

1. Adding `created_at` and `updated_at` timestamps to `TokenGet`.
2. Adding an optional `expires_at` timestamp to `TokenCreate`.