### PR TITLE
Extend PipelineCreate fields

### DIFF
--- a/pipeline/api/cloud.py
+++ b/pipeline/api/cloud.py
@@ -4,7 +4,7 @@ import io
 import json
 import os
 import urllib.parse
-from typing import TYPE_CHECKING, Any, List, Optional, Union
+from typing import TYPE_CHECKING, Any, List, Optional, Set, Union
 
 import requests
 from requests_toolbelt.multipart import encoder
@@ -171,7 +171,13 @@ class PipelineCloud:
 
         return ModelGet.parse_obj(request_result)
 
-    def upload_pipeline(self, new_pipeline_graph: Graph) -> PipelineGet:
+    def upload_pipeline(
+        self,
+        new_pipeline_graph: Graph,
+        public: bool = False,
+        description: str = "",
+        tags: Set[str] = None,
+    ) -> PipelineGet:
 
         new_name = new_pipeline_graph.name
         print("Uploading functions")
@@ -212,6 +218,9 @@ class PipelineCloud:
             models=new_models,
             graph_nodes=new_graph_nodes,
             outputs=new_outputs,
+            public=public,
+            description=description,
+            tags=tags or set(),
         )
         print("Uploading pipeline graph")
         request_result = self._post(

--- a/pipeline/schemas/pipeline.py
+++ b/pipeline/schemas/pipeline.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import List, Optional, Set
+from typing import Dict, List, Optional, Set
 
 from pydantic import Field, root_validator
 
@@ -69,6 +69,8 @@ class PipelineGetDetailed(PipelineGet):
     updated_at: datetime
     last_run: Optional[datetime]
     public: bool
+    # Maps language, e.g. `curl` or `python`, to an example Run creation code snippet
+    run_examples: Dict[str, str] = {}
 
 
 class PipelineCreate(BaseModel):

--- a/pipeline/schemas/pipeline.py
+++ b/pipeline/schemas/pipeline.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import List, Optional
+from typing import List, Optional, Set
 
 from pydantic import Field, root_validator
 
@@ -79,3 +79,6 @@ class PipelineCreate(BaseModel):
     graph_nodes: List[PipelineGraphNode]
     outputs: List[str]
     project_id: Optional[str]
+    public: bool = False
+    description: str = ""
+    tags: Set[str] = set()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pipeline-ai"
-version = "0.0.34"
+version = "0.0.35"
 description = "Pipelines for machine learning workloads."
 authors = [
   "Paul Hetherington <ph@mystic.ai>",


### PR DESCRIPTION
1. Adds some of the fields recently added to Pipeline's API to the Pipeline creation schema.
2. Allows setting the new fields when uploading a Pipeline.
3. Add a `run_examples` field to detailed schema to support language-dependent usage snippets.
4. Bump version.