### PR TITLE
[BE-59] - download function and unpickle hex

### DIFF
--- a/pipeline/api/cloud.py
+++ b/pipeline/api/cloud.py
@@ -373,9 +373,6 @@ class PipelineCloud:
             Parameters:
                     id (str):
                         The id for the desired function
-                    populate_data (bool):
-                        Flag to set if Data fild within the function
-                        should be populated with the associated data.
 
             Returns:
                     function (Any): De-Serialized function.

--- a/pipeline/api/cloud.py
+++ b/pipeline/api/cloud.py
@@ -366,7 +366,7 @@ class PipelineCloud:
         except ValidationError as e:
             raise InvalidSchema(schema=schema.__name__, message=str(e))
 
-    def download_function(self, id: str, populate_data: bool = False) -> Function:
+    def download_function(self, id: str) -> Function:
         """
         Downloads Function object from Pipeline Cloud.
 
@@ -380,11 +380,10 @@ class PipelineCloud:
             Returns:
                     function (Any): De-Serialized function.
         """
-        # f"/v2/functions/{id}", params=dict(return_data=populate_data)
         endpoint = f"/v2/functions/{id}"
         f_get_schema: FunctionGet = self._download_schema(
             schema=FunctionGet,
             endpoint=endpoint,
-            params=dict(return_data=populate_data),
+            params=dict(return_data=True),
         )
         return hex_to_python_object(f_get_schema.hex_file.data)

--- a/pipeline/api/cloud.py
+++ b/pipeline/api/cloud.py
@@ -362,7 +362,7 @@ class PipelineCloud:
         """
         response = self._get(endpoint=endpoint, params=params)
         try:
-            return schema(**dict(response))
+            return schema(**response)
         except ValidationError as e:
             raise InvalidSchema(schema=schema.__name__, message=str(e))
 

--- a/pipeline/api/cloud.py
+++ b/pipeline/api/cloud.py
@@ -5,7 +5,7 @@ import json
 import os
 import urllib.parse
 from http import HTTPStatus
-from typing import TYPE_CHECKING, Any, List, Optional, Set, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Type, Union
 
 import requests
 from pydantic import ValidationError
@@ -14,13 +14,19 @@ from tqdm import tqdm
 
 from pipeline.exceptions.InvalidSchema import InvalidSchema
 from pipeline.exceptions.MissingActiveToken import MissingActiveToken
+from pipeline.schemas.base import BaseModel
 from pipeline.schemas.data import DataGet
 from pipeline.schemas.file import FileCreate, FileGet
 from pipeline.schemas.function import FunctionCreate, FunctionGet
 from pipeline.schemas.model import ModelCreate, ModelGet
 from pipeline.schemas.pipeline import PipelineCreate, PipelineGet, PipelineVariableGet
 from pipeline.schemas.run import RunCreate
-from pipeline.util import generate_id, python_object_to_hex, python_object_to_name
+from pipeline.util import (
+    generate_id,
+    hex_to_python_object,
+    python_object_to_hex,
+    python_object_to_name,
+)
 from pipeline.util.logging import PIPELINE_STR
 
 if TYPE_CHECKING:
@@ -100,6 +106,16 @@ class PipelineCloud:
         return self.upload_file(
             io.BytesIO(python_object_to_hex(obj).encode()), remote_path
         )
+
+    def _get(self, endpoint: str, params: Dict[str, Any] = None):
+        headers = {
+            "Authorization": "Bearer %s" % self.token,
+        }
+
+        url = urllib.parse.urljoin(self.url, endpoint)
+        response = requests.get(url, headers=headers, params=params)
+        response.raise_for_status()
+        return response.json()
 
     def _post(self, endpoint, json_data):
         self.raise_for_invalid_token()
@@ -329,3 +345,46 @@ class PipelineCloud:
 
         run_create_schema = RunCreate(pipeline_id=pipeline_id, data_id=_data_id)
         return self._post("/v2/runs", json.loads(run_create_schema.json()))
+
+    def _download_schema(
+        self, schema: Type[BaseModel], endpoint: str, params: Optional[Dict[str, Any]]
+    ) -> Type[BaseModel]:
+        """
+        Request json data to a given endpoint and parse it into given schema
+
+            Parameters:
+                schema (Type[BaseModel]): Which schema is expected to be returned
+                endpoint (str): endpoint to which the request must be sent
+                params (Optional[Dict[str, Any]]): optional request params
+
+            Returns:
+                schema (Type[BaseModel]): The populated schema passed in
+        """
+        response = self._get(endpoint=endpoint, params=params)
+        try:
+            return schema(**dict(response))
+        except ValidationError as e:
+            raise InvalidSchema(schema=schema.__name__, message=str(e))
+
+    def download_function(self, id: str, populate_data: bool = False) -> Function:
+        """
+        Downloads Function object from Pipeline Cloud.
+
+            Parameters:
+                    id (str):
+                        The id for the desired function
+                    populate_data (bool):
+                        Flag to set if Data fild within the function
+                        should be populated with the associated data.
+
+            Returns:
+                    function (Any): De-Serialized function.
+        """
+        # f"/v2/functions/{id}", params=dict(return_data=populate_data)
+        endpoint = f"/v2/functions/{id}"
+        f_get_schema: FunctionGet = self._download_schema(
+            schema=FunctionGet,
+            endpoint=endpoint,
+            params=dict(return_data=populate_data),
+        )
+        return hex_to_python_object(f_get_schema.hex_file.data)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,7 @@ from pipeline.schemas.file import FileGet
 from pipeline.schemas.function import FunctionGet
 from pipeline.schemas.project import ProjectGet
 from pipeline.schemas.runnable import RunnableType
+from pipeline.util import python_object_to_hex
 
 python_content = """
 from pipeline.objects import Pipeline, Variable, pipeline_function
@@ -86,7 +87,7 @@ def file_get_json():
         "name": "test",
         "id": "file_test",
         "path": "test/path/to/file",
-        "data": cloudpickle.dumps("data").hex(),
+        "data": python_object_to_hex("data"),
         "file_size": 8,
     }
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,9 @@ from responses import matchers
 from pipeline.objects import Pipeline, Variable, pipeline_function, pipeline_model
 from pipeline.schemas.data import DataGet
 from pipeline.schemas.file import FileGet
+from pipeline.schemas.function import FunctionGet
+from pipeline.schemas.project import ProjectGet
+from pipeline.schemas.runnable import RunnableType
 
 python_content = """
 from pipeline.objects import Pipeline, Variable, pipeline_function
@@ -23,7 +26,8 @@ def test_with_decorator():
 
 
 @pytest.fixture
-def api_response(url, token, bad_token, file_get_json):
+def api_response(url, token, bad_token, file_get_json, function_get_json):
+    function_get_id = function_get_json["id"]
     with responses.RequestsMock(assert_all_requests_are_fired=False) as rsps:
         rsps.add(
             responses.GET,
@@ -44,6 +48,13 @@ def api_response(url, token, bad_token, file_get_json):
             url + "/v2/files/",
             json=file_get_json,
             status=201,
+            match=[matchers.header_matcher({"Authorization": "Bearer " + token})],
+        )
+        rsps.add(
+            responses.GET,
+            url + f"/v2/functions/{function_get_id}",
+            json=function_get_json,
+            status=200,
             match=[matchers.header_matcher({"Authorization": "Bearer " + token})],
         )
         yield rsps
@@ -75,15 +86,65 @@ def file_get_json():
         "name": "test",
         "id": "file_test",
         "path": "test/path/to/file",
-        "data": "data",
+        "data": cloudpickle.dumps("data").hex(),
         "file_size": 8,
     }
 
 
 @pytest.fixture()
+def project_get_json():
+    return {
+        "avatar_colour": "#AA2216",
+        "avatar_image_url": None,
+        "name": "test_name",
+        "id": "test_project_id",
+    }
+
+
+@pytest.fixture()
+def function_get_json(file_get_json, project_get_json):
+    return {
+        "id": "test_function_id",
+        "type": "function",
+        "name": "test_name",
+        "project": project_get_json,
+        "hex_file": file_get_json,
+        "source_sample": "test_source",
+        "inputs": [],
+        "output": [],
+    }
+
+
+@pytest.fixture()
+def project_get():
+    return ProjectGet(
+        name="test_name",
+        id="test_project_id",
+        avatar_colour="#AA2216",
+        avatar_image_url=None,
+    )
+
+
+@pytest.fixture()
+def function_get(file_get, project_get):
+    return FunctionGet(
+        name="test_name",
+        id="test_function_id",
+        type=RunnableType.function,
+        project=project_get,
+        hex_file=file_get,
+        source_sample="test_source",
+    )
+
+
+@pytest.fixture()
 def file_get():
     return FileGet(
-        name="test", id="file_test", path="test/path/to/file", data="data", file_size=8
+        name="test",
+        id="file_test",
+        path="test/path/to/file",
+        data="data",
+        file_size=8,
     )
 
 

--- a/tests/test_pipeline_cloud.py
+++ b/tests/test_pipeline_cloud.py
@@ -3,6 +3,7 @@ import pytest
 from pipeline import PipelineCloud
 from pipeline.exceptions.InvalidSchema import InvalidSchema
 from pipeline.exceptions.MissingActiveToken import MissingActiveToken
+from pipeline.util import hex_to_python_object
 
 
 @pytest.mark.usefixtures("api_response")
@@ -21,6 +22,8 @@ def test_cloud_init_failure(url, bad_token):
 def test_cloud_upload_file(url, token, file_get, tmp_file):
     api = PipelineCloud(url, token)
     f = api.upload_file(tmp_file, "remote_path")
+    # recover data field just to simplify assertion
+    f.data = hex_to_python_object(f.data)
     assert f == file_get
 
 
@@ -29,3 +32,10 @@ def test_cloud_upload_function_fail(url, token):
     api = PipelineCloud(url, token)
     with pytest.raises(InvalidSchema):
         api.upload_function("")
+
+
+@pytest.mark.usefixtures("api_response")
+def test_cloud_download_function(url, token, function_get, file_get):
+    api = PipelineCloud(url, token)
+    f = api.download_function(function_get.id)
+    assert f == file_get.data


### PR DESCRIPTION
Enable retrieving `Get` schemas from Pipeline-Top endpoints.

Once the data has been retrieved via the function get endpoint we must reform the python object from the hex string in the FileGet schema.