### PR TITLE
[BE-103][BE-105] Brendan/handle undeployed pipeline

### DIFF
--- a/pipeline/api/cloud.py
+++ b/pipeline/api/cloud.py
@@ -361,9 +361,6 @@ class PipelineCloud:
             )
 
         run_create_schema = RunCreate(pipeline_id=pipeline_id, data_id=_data_id)
-        # TODO Create a GET request that checks the pipeline is deployed and
-        # handle this separately if not. Currently is handled crudely in a
-        # generic Exception in _post()
         return self._post("/v2/runs", json.loads(run_create_schema.json()))
 
     def _download_schema(

--- a/pipeline/api/cloud.py
+++ b/pipeline/api/cloud.py
@@ -137,8 +137,6 @@ class PipelineCloud:
             try:
                 response.raise_for_status()
             except:
-                # TODO Create a GET request that checks that a pipeline is deployed
-                # before running it.
                 content = json.loads(response.content.decode("utf-8"))
                 detail = content["detail"] if "detail" in content.keys() else UNKNOWN_ERROR_MESSAGE
                 raise Exception(f"Error {response.status_code}: {str(detail)}")
@@ -354,6 +352,9 @@ class PipelineCloud:
             )
 
         run_create_schema = RunCreate(pipeline_id=pipeline_id, data_id=_data_id)
+        # TODO Create a GET request that checks the pipeline is deployed and 
+        # handle this separately if not. Currently is handled crudely in a
+        # generic Exception in _post()
         return self._post("/v2/runs", json.loads(run_create_schema.json()))
 
     def _download_schema(

--- a/pipeline/api/cloud.py
+++ b/pipeline/api/cloud.py
@@ -36,6 +36,7 @@ UNKNOWN_ERROR_MESSAGE = (
     "There was an internal error. If this persists please contact support@mystic.ai"
 )
 
+
 class PipelineCloud:
     token: Optional[str]
     url: Optional[str]
@@ -136,9 +137,13 @@ class PipelineCloud:
         else:
             try:
                 response.raise_for_status()
-            except:
+            except requests.exceptions.HTTPError:
                 content = json.loads(response.content.decode("utf-8"))
-                detail = content["detail"] if "detail" in content.keys() else UNKNOWN_ERROR_MESSAGE
+                detail = (
+                    content["detail"]
+                    if "detail" in content.keys()
+                    else UNKNOWN_ERROR_MESSAGE
+                )
                 raise Exception(f"Error {response.status_code}: {str(detail)}")
 
         return response.json()
@@ -352,7 +357,7 @@ class PipelineCloud:
             )
 
         run_create_schema = RunCreate(pipeline_id=pipeline_id, data_id=_data_id)
-        # TODO Create a GET request that checks the pipeline is deployed and 
+        # TODO Create a GET request that checks the pipeline is deployed and
         # handle this separately if not. Currently is handled crudely in a
         # generic Exception in _post()
         return self._post("/v2/runs", json.loads(run_create_schema.json()))

--- a/pipeline/api/cloud.py
+++ b/pipeline/api/cloud.py
@@ -107,7 +107,7 @@ class PipelineCloud:
                 detail = ""
             detail = detail or ""
             # If a message was delivered we want to show that. Otherwise it's a
-            # standard HTTP error and should be handled my raise_for_status()
+            # standard HTTP error and should be handled by raise_for_status()
             if message is not None:
                 raise Exception(f"Error {response.status_code}: {message} {detail}")
             else:

--- a/pipeline/api/cloud.py
+++ b/pipeline/api/cloud.py
@@ -96,7 +96,7 @@ class PipelineCloud:
             content = response.json()
             # Every exception has content of {detail, status_code[, headers]}
             # TODO Some exceptions in Top send detail as a string and not a dict.
-            # These exceptions are now handled like normal HTTP excpetions.
+            # These exceptions are now handled like normal HTTP exceptions.
             # Need to rewrite these to all have the same format.
             detail = content.pop("detail", "")
             message = None

--- a/pipeline/api/cloud.py
+++ b/pipeline/api/cloud.py
@@ -32,10 +32,6 @@ from pipeline.util.logging import PIPELINE_STR
 if TYPE_CHECKING:
     from pipeline.objects import Function, Graph, Model
 
-UNKNOWN_ERROR_MESSAGE = (
-    "There was an internal error. If this persists please contact support@mystic.ai"
-)
-
 
 class PipelineCloud:
     token: Optional[str]

--- a/pipeline/api/cloud.py
+++ b/pipeline/api/cloud.py
@@ -32,6 +32,9 @@ from pipeline.util.logging import PIPELINE_STR
 if TYPE_CHECKING:
     from pipeline.objects import Function, Graph, Model
 
+UNKNOWN_ERROR_MESSAGE = (
+    "There was an internal error. If this persists please contact support@mystic.ai"
+)
 
 class PipelineCloud:
     token: Optional[str]
@@ -131,7 +134,14 @@ class PipelineCloud:
             schema = json_data
             raise InvalidSchema(schema=schema)
         else:
-            response.raise_for_status()
+            try:
+                response.raise_for_status()
+            except:
+                # TODO Create a GET request that checks that a pipeline is deployed
+                # before running it.
+                content = json.loads(response.content.decode("utf-8"))
+                detail = content["detail"] if "detail" in content.keys() else UNKNOWN_ERROR_MESSAGE
+                raise Exception(f"Error {response.status_code}: {str(detail)}")
 
         return response.json()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pipeline-ai"
-version = "0.0.38b7"
+version = "0.0.38b8"
 description = "Pipelines for machine learning workloads."
 authors = [
   "Paul Hetherington <ph@mystic.ai>",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pipeline-ai"
-version = "0.0.38b8"
+version = "0.0.38b9"
 description = "Pipelines for machine learning workloads."
 authors = [
   "Paul Hetherington <ph@mystic.ai>",


### PR DESCRIPTION
A fairly crude handling of the error created when a user tries to run a pipeline they haven't deployed. Specifically I've written a generic handler that spits out the message that's sent by Top when before it was just being handled as an HTTP error with no helpful message. The issue is that we have many errors that arise in Top that are sent as generic HTTP 4xx errors. A much better implementation would be to GET request Top first to check their pipeline is deployed, since this is potentially a very common user error. Then we can easily handle this specific case without resorting to a generic handler.