### PR TITLE
Add concept of compute requirements for a Run, Pipeline and Function

### DIFF
--- a/pipeline/schemas/compute_requirements.py
+++ b/pipeline/schemas/compute_requirements.py
@@ -1,0 +1,9 @@
+from typing import Optional
+
+from .base import BaseModel
+
+
+class ComputeRequirements(BaseModel):
+    """Additional compute requirements required by a runnable (e.g. min GPU VRAM)"""
+
+    min_gpu_vram_mb: Optional[int]

--- a/pipeline/schemas/compute_requirements.py
+++ b/pipeline/schemas/compute_requirements.py
@@ -1,6 +1,13 @@
+from enum import Enum
 from typing import Optional
 
 from .base import BaseModel
+
+
+# https://github.com/samuelcolvin/pydantic/issues/2278
+class ComputeType(str, Enum):
+    cpu: str = "cpu"
+    gpu: str = "gpu"
 
 
 class ComputeRequirements(BaseModel):

--- a/pipeline/schemas/function.py
+++ b/pipeline/schemas/function.py
@@ -20,8 +20,6 @@ class FunctionGet(RunnableGet):
     source_sample: str
     type: RunnableType = Field(RunnableType.function, const=True)
 
-    compute_requirements: Optional[ComputeRequirements]
-
     class Config:
         orm_mode = True
 

--- a/pipeline/schemas/function.py
+++ b/pipeline/schemas/function.py
@@ -3,6 +3,7 @@ from typing import List, Optional
 from pydantic import Field, root_validator
 
 from pipeline.schemas.base import BaseModel
+from pipeline.schemas.compute_requirements import ComputeRequirements
 from pipeline.schemas.file import FileCreate, FileGet
 from pipeline.schemas.runnable import RunnableGet, RunnableType
 
@@ -18,6 +19,8 @@ class FunctionGet(RunnableGet):
 
     source_sample: str
     type: RunnableType = Field(RunnableType.function, const=True)
+
+    compute_requirements: Optional[ComputeRequirements]
 
     class Config:
         orm_mode = True
@@ -78,6 +81,8 @@ class FunctionCreate(BaseModel):
 
     file_id: Optional[str]
     file: Optional[FileCreate]
+
+    compute_requirements: Optional[ComputeRequirements]
 
     @root_validator
     def file_or_id_validation(cls, values):

--- a/pipeline/schemas/function.py
+++ b/pipeline/schemas/function.py
@@ -3,7 +3,7 @@ from typing import List, Optional
 from pydantic import Field, root_validator
 
 from pipeline.schemas.base import BaseModel
-from pipeline.schemas.compute_requirements import ComputeRequirements
+from pipeline.schemas.compute_requirements import ComputeRequirements, ComputeType
 from pipeline.schemas.file import FileCreate, FileGet
 from pipeline.schemas.runnable import RunnableGet, RunnableType
 
@@ -82,6 +82,8 @@ class FunctionCreate(BaseModel):
     file_id: Optional[str]
     file: Optional[FileCreate]
 
+    # By default a Pipeline will require GPU resources
+    compute_type: ComputeType = ComputeType.gpu
     compute_requirements: Optional[ComputeRequirements]
 
     @root_validator

--- a/pipeline/schemas/function.py
+++ b/pipeline/schemas/function.py
@@ -82,7 +82,7 @@ class FunctionCreate(BaseModel):
     file_id: Optional[str]
     file: Optional[FileCreate]
 
-    # By default a Pipeline will require GPU resources
+    # By default a Function will require GPU resources
     compute_type: ComputeType = ComputeType.gpu
     compute_requirements: Optional[ComputeRequirements]
 

--- a/pipeline/schemas/pipeline.py
+++ b/pipeline/schemas/pipeline.py
@@ -58,8 +58,6 @@ class PipelineGet(PipelineGetBrief, RunnableGet):
     models: List[ModelGet]
     graph_nodes: List[PipelineGraphNode]
     outputs: List[str]
-    # By default a Pipeline will require GPU resources
-    compute_type: ComputeType = ComputeType.gpu
     compute_requirements: Optional[ComputeRequirements]
 
     class Config:
@@ -88,4 +86,6 @@ class PipelineCreate(BaseModel):
     public: bool = False
     description: str = ""
     tags: Set[str] = set()
+    # By default a Pipeline will require GPU resources
+    compute_type: ComputeType = ComputeType.gpu
     compute_requirements: Optional[ComputeRequirements]

--- a/pipeline/schemas/pipeline.py
+++ b/pipeline/schemas/pipeline.py
@@ -58,7 +58,6 @@ class PipelineGet(PipelineGetBrief, RunnableGet):
     models: List[ModelGet]
     graph_nodes: List[PipelineGraphNode]
     outputs: List[str]
-    compute_requirements: Optional[ComputeRequirements]
 
     class Config:
         orm_mode = True

--- a/pipeline/schemas/pipeline.py
+++ b/pipeline/schemas/pipeline.py
@@ -4,7 +4,7 @@ from typing import Dict, List, Optional, Set
 from pydantic import Field, root_validator
 
 from pipeline.schemas.base import BaseModel
-from pipeline.schemas.compute_requirements import ComputeRequirements
+from pipeline.schemas.compute_requirements import ComputeRequirements, ComputeType
 from pipeline.schemas.file import FileGet
 from pipeline.schemas.function import FunctionGet
 from pipeline.schemas.model import ModelGet
@@ -58,6 +58,8 @@ class PipelineGet(PipelineGetBrief, RunnableGet):
     models: List[ModelGet]
     graph_nodes: List[PipelineGraphNode]
     outputs: List[str]
+    # By default a Pipeline will require GPU resources
+    compute_type: ComputeType = ComputeType.gpu
     compute_requirements: Optional[ComputeRequirements]
 
     class Config:

--- a/pipeline/schemas/pipeline.py
+++ b/pipeline/schemas/pipeline.py
@@ -4,6 +4,7 @@ from typing import Dict, List, Optional, Set
 from pydantic import Field, root_validator
 
 from pipeline.schemas.base import BaseModel
+from pipeline.schemas.compute_requirements import ComputeRequirements
 from pipeline.schemas.file import FileGet
 from pipeline.schemas.function import FunctionGet
 from pipeline.schemas.model import ModelGet
@@ -57,6 +58,7 @@ class PipelineGet(PipelineGetBrief, RunnableGet):
     models: List[ModelGet]
     graph_nodes: List[PipelineGraphNode]
     outputs: List[str]
+    compute_requirements: Optional[ComputeRequirements]
 
     class Config:
         orm_mode = True
@@ -84,3 +86,4 @@ class PipelineCreate(BaseModel):
     public: bool = False
     description: str = ""
     tags: Set[str] = set()
+    compute_requirements: Optional[ComputeRequirements]

--- a/pipeline/schemas/run.py
+++ b/pipeline/schemas/run.py
@@ -4,7 +4,7 @@ from typing import Any, List, Optional, Union
 
 from pydantic import root_validator
 
-from pipeline.schemas.compute_requirements import ComputeRequirements
+from pipeline.schemas.compute_requirements import ComputeRequirements, ComputeType
 from pipeline.schemas.file import FileGet
 from pipeline.schemas.function import FunctionGet, FunctionGetDetailed
 from pipeline.schemas.pipeline import PipelineGet, PipelineGetDetailed
@@ -33,12 +33,6 @@ class RunError(Enum):
     MAX_RETRIES = "max_retries"
     PIPELINE_FAULT = "pipeline_fault"
     UNSATISFIABLE = "unsatisfiable"
-
-
-# https://github.com/samuelcolvin/pydantic/issues/2278
-class ComputeType(str, Enum):
-    cpu: str = "cpu"
-    gpu: str = "gpu"
 
 
 class RunCreate(BaseModel):

--- a/pipeline/schemas/run.py
+++ b/pipeline/schemas/run.py
@@ -88,7 +88,6 @@ class RunGet(BaseModel):
     #: JSON-serialised runnable return value, if available
     result_preview: Optional[Union[list, dict]]
     error: Optional[RunError]
-    compute_requirements: Optional[ComputeRequirements]
 
     class Config:
         allow_population_by_field_name = True

--- a/pipeline/schemas/run.py
+++ b/pipeline/schemas/run.py
@@ -4,6 +4,7 @@ from typing import Any, List, Optional, Union
 
 from pydantic import root_validator
 
+from pipeline.schemas.compute_requirements import ComputeRequirements
 from pipeline.schemas.file import FileGet
 from pipeline.schemas.function import FunctionGet, FunctionGetDetailed
 from pipeline.schemas.pipeline import PipelineGet, PipelineGetDetailed
@@ -48,6 +49,7 @@ class RunCreate(BaseModel):
     blocking: Optional[bool] = False
     # By default a Run will require GPU resources
     compute_type: ComputeType = ComputeType.gpu
+    compute_requirements: Optional[ComputeRequirements]
 
     @root_validator
     def pipeline_data_val(cls, values):
@@ -92,6 +94,7 @@ class RunGet(BaseModel):
     #: JSON-serialised runnable return value, if available
     result_preview: Optional[Union[list, dict]]
     error: Optional[RunError]
+    compute_requirements: Optional[ComputeRequirements]
 
     class Config:
         allow_population_by_field_name = True

--- a/pipeline/schemas/run.py
+++ b/pipeline/schemas/run.py
@@ -41,8 +41,7 @@ class RunCreate(BaseModel):
     data: Optional[Any]
     data_id: Optional[str]
     blocking: Optional[bool] = False
-    # By default a Run will require GPU resources
-    compute_type: ComputeType = ComputeType.gpu
+    compute_type: Optional[ComputeType]
     compute_requirements: Optional[ComputeRequirements]
 
     @root_validator

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pipeline-ai"
-version = "0.0.38b9"
+version = "0.0.38b10"
 description = "Pipelines for machine learning workloads."
 authors = [
   "Paul Hetherington <ph@mystic.ai>",


### PR DESCRIPTION
## Changes

- Added `ComputeRequirements` for `Run` (which can be given defaults at the `Pipeline`/`Function` level)
- Added `compute_type` to `Pipeline`s and `Function`s too (since it feels sensible if they can specify compute requirements they should also be able to specify the compute type)

## Questions/Comments

- So far I've only added a single optional compute requirement, `min_gpu_vram_mb` (not sure if this is the best name or if just `min_vram_mb` would be better?)
- Not sure whether to add these fields to the response schemas such as `PipelineGet`?