### PR TITLE
Allow clients to specify compute requirements

### DIFF
--- a/pipeline/api/cloud.py
+++ b/pipeline/api/cloud.py
@@ -15,6 +15,7 @@ from tqdm import tqdm
 from pipeline.exceptions.InvalidSchema import InvalidSchema
 from pipeline.exceptions.MissingActiveToken import MissingActiveToken
 from pipeline.schemas.base import BaseModel
+from pipeline.schemas.compute_requirements import ComputeRequirements
 from pipeline.schemas.data import DataGet
 from pipeline.schemas.file import FileCreate, FileGet
 from pipeline.schemas.function import FunctionCreate, FunctionGet
@@ -303,6 +304,13 @@ class PipelineCloud:
             _node.to_create_schema() for _node in new_pipeline_graph.nodes
         ]
         new_outputs = [_output.local_id for _output in new_pipeline_graph.outputs]
+
+        compute_requirements = None
+        if new_pipeline_graph.min_gpu_vram_mb:
+            compute_requirements = ComputeRequirements(
+                min_gpu_vram_mb=new_pipeline_graph.min_gpu_vram_mb
+            )
+
         try:
             pipeline_create_schema = PipelineCreate(
                 name=new_name,
@@ -314,6 +322,8 @@ class PipelineCloud:
                 public=public,
                 description=description,
                 tags=tags or set(),
+                compute_type=new_pipeline_graph.compute_type,
+                compute_requirements=compute_requirements,
             )
         except ValidationError as e:
             raise InvalidSchema(schema="Graph", message=str(e))
@@ -328,6 +338,8 @@ class PipelineCloud:
         self,
         pipeline_id_or_schema: Union[str, PipelineGet],
         raw_data_or_schema: Union[Any, DataGet],
+        compute_type: Optional[str] = None,
+        min_gpu_vram_mb: Optional[int] = None,
     ):
         """
         Uploads Data and executes a Run of given pipeline over given data.
@@ -339,6 +351,14 @@ class PipelineCloud:
                     raw_data_or_schema (Union[Any, DataGet]):
                         Raw data for Pipeline execution
                         or schema for already uploaded data.
+                    compute_type (Optional[str]):
+                        Compute type requirement for this run (e.g. "cpu" or "gpu"). If
+                        not defined, it will fallback to that specified by the Pipeline
+                        itself (typically this is "gpu")
+                    min_gpu_vram_mb (Optional[int]):
+                        Minimum amount of GPU VRAM required. If not defined, it will
+                        fallback to that specified by the Pipeline (if applicable). This
+                        should only be specified for GPU workloads.
 
             Returns:
                     run (Any): Run object containing metadata and outputs.
@@ -367,7 +387,16 @@ class PipelineCloud:
                 ),
             )
 
-        run_create_schema = RunCreate(pipeline_id=pipeline_id, data_id=_data_id)
+        compute_requirements = None
+        if min_gpu_vram_mb:
+            compute_requirements = ComputeRequirements(min_gpu_vram_mb=min_gpu_vram_mb)
+
+        run_create_schema = RunCreate(
+            pipeline_id=pipeline_id,
+            data_id=_data_id,
+            compute_type=compute_type,
+            compute_requirements=compute_requirements,
+        )
         return self._post("/v2/runs", json.loads(run_create_schema.json()))
 
     def _download_schema(

--- a/pipeline/objects/graph.py
+++ b/pipeline/objects/graph.py
@@ -26,6 +26,9 @@ class Graph:
     models: List[Model]
     # TODO: Add generic objects (e.g. Model) to be included in the graph
 
+    compute_type: str
+    min_gpu_vram_mb: int
+
     def __init__(
         self,
         *,
@@ -35,6 +38,8 @@ class Graph:
         outputs: List[Variable] = None,
         nodes: List[GraphNode] = None,
         models: List[Model] = None,
+        compute_type: str = "gpu",
+        min_gpu_vram_mb: int = None,
     ):
         self.name = name
         self.local_id = generate_id(10)
@@ -44,6 +49,8 @@ class Graph:
         self.outputs = outputs if outputs is not None else []
         self.nodes = nodes if nodes is not None else []
         self.models = models if models is not None else []
+        self.compute_type = compute_type
+        self.min_gpu_vram_mb = min_gpu_vram_mb
         # Flag set when all models have had their `load()` methods called
         self._loaded = False
 

--- a/pipeline/objects/pipeline.py
+++ b/pipeline/objects/pipeline.py
@@ -15,15 +15,29 @@ class Pipeline:
     _pipeline_context_active: bool = False
     _pipeline_context_name: str = None
     _api: PipelineCloud = None
+    _compute_type: str = "gpu"
+    _min_gpu_vram_mb: int = None
 
-    def __init__(self, new_pipeline_name: str, api: PipelineCloud = None):
+    def __init__(
+        self,
+        new_pipeline_name: str,
+        api: PipelineCloud = None,
+        compute_type: str = "gpu",
+        min_gpu_vram_mb: int = None,
+    ):
         self._pipeline_context_name = new_pipeline_name
         self._api = api or PipelineCloud()
+        self._compute_type = compute_type
+        self._min_gpu_vram_mb = min_gpu_vram_mb
 
     def __enter__(self):
         Pipeline._pipeline_context_active = True
 
-        Pipeline._current_pipeline = Graph(name=self._pipeline_context_name)
+        Pipeline._current_pipeline = Graph(
+            name=self._pipeline_context_name,
+            compute_type=self._compute_type,
+            min_gpu_vram_mb=self._min_gpu_vram_mb,
+        )
 
         return self
 

--- a/pipeline/schemas/pipeline.py
+++ b/pipeline/schemas/pipeline.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from typing import Dict, List, Optional, Set
 
-from pydantic import Field, root_validator
+from pydantic import Field, root_validator, validator
 
 from pipeline.schemas.base import BaseModel
 from pipeline.schemas.compute_requirements import ComputeRequirements, ComputeType
@@ -88,3 +88,15 @@ class PipelineCreate(BaseModel):
     # By default a Pipeline will require GPU resources
     compute_type: ComputeType = ComputeType.gpu
     compute_requirements: Optional[ComputeRequirements]
+
+    @validator("compute_requirements")
+    def compute_type_is_gpu(cls, v, values):
+        """If compute_type is not 'gpu' we don't expect any additional compute
+        requirements to be specified.
+        """
+        if values["compute_type"] != ComputeType.gpu:
+            if v and v.min_gpu_vram_mb:
+                raise ValueError(
+                    "min_gpu_vram_mb should only be specified for gpu workloads"
+                )
+        return v

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -357,3 +357,30 @@ def model_get_json(model_get, model_file_get_json):
         "hex_file": model_file_get_json,
         "source_sample": model_get.source_sample,
     }
+
+
+@pytest.fixture()
+def pipeline_graph_with_compute_requirements():
+    @pipeline_model()
+    class CustomModel:
+        def __init__(self, model_path="", tokenizer_path=""):
+            self.model_path = model_path
+            self.tokenizer_path = tokenizer_path
+
+        @pipeline_function
+        def predict(self, input: str, **kwargs: dict) -> str:
+            return input + " lol"
+
+        @pipeline_function
+        def load(self) -> None:
+            print("load")
+
+    with Pipeline("test", compute_type="gpu", min_gpu_vram_mb=4000) as my_pipeline:
+        in_1 = Variable(str, is_input=True)
+        my_pipeline.add_variable(in_1)
+
+        my_model = CustomModel()
+        str_1 = my_model.predict(in_1)
+
+        my_pipeline.output(str_1)
+    return Pipeline.get_pipeline("test")

--- a/tests/schemas/test_pipeline.py
+++ b/tests/schemas/test_pipeline.py
@@ -1,3 +1,5 @@
+import json
+
 import pytest
 
 from pipeline.schemas.compute_requirements import ComputeRequirements
@@ -77,3 +79,30 @@ def test_compute_type_is_gpu_validator(test):
         )
         assert schema.compute_type == test["expected"]["compute_type"]
         assert schema.compute_requirements == test["expected"]["compute_requirements"]
+
+
+def test_pipeline_create_to_json():
+    schema = PipelineCreate(
+        name="pipe",
+        variables=[],
+        functions=[],
+        models=[],
+        graph_nodes=[],
+        outputs=[],
+        compute_type="gpu",
+        compute_requirements=ComputeRequirements(min_gpu_vram_mb=4000),
+    )
+    assert json.loads(schema.json()) == dict(
+        name="pipe",
+        description="",
+        project_id=None,
+        public=False,
+        tags=[],
+        variables=[],
+        functions=[],
+        models=[],
+        graph_nodes=[],
+        outputs=[],
+        compute_type="gpu",
+        compute_requirements=dict(min_gpu_vram_mb=4000),
+    )

--- a/tests/schemas/test_pipeline.py
+++ b/tests/schemas/test_pipeline.py
@@ -1,0 +1,79 @@
+import pytest
+
+from pipeline.schemas.compute_requirements import ComputeRequirements
+from pipeline.schemas.pipeline import PipelineCreate
+
+
+@pytest.mark.parametrize(
+    "test",
+    [
+        {
+            "comment": "Valid example: neither compute type nor compute requirements",
+            "input": {"compute_type": "gpu"},
+            "expected_exception": None,
+            "expected": {"compute_type": "gpu", "compute_requirements": None},
+        },
+        {
+            "comment": "Valid example: compute type gpu and no compute requirements",
+            "input": {"compute_type": "gpu"},
+            "expected_exception": None,
+            "expected": {"compute_type": "gpu", "compute_requirements": None},
+        },
+        {
+            "comment": "Valid example: compute type cpu and no compute requirements",
+            "input": {"compute_type": "cpu"},
+            "expected_exception": None,
+            "expected": {"compute_type": "cpu", "compute_requirements": None},
+        },
+        {
+            "comment": "Valid example: compute type gpu and compute requirements",
+            "input": {
+                "compute_type": "gpu",
+                "compute_requirements": ComputeRequirements(min_gpu_vram_mb=4000),
+            },
+            "expected_exception": None,
+            "expected": {
+                "compute_type": "gpu",
+                "compute_requirements": ComputeRequirements(min_gpu_vram_mb=4000),
+            },
+        },
+        {
+            "comment": "Invalid example: compute type cpu and compute requirements",
+            "input": {
+                "compute_type": "cpu",
+                "compute_requirements": ComputeRequirements(min_gpu_vram_mb=4000),
+            },
+            "expected_exception": ValueError,
+        },
+    ],
+)
+def test_compute_type_is_gpu_validator(test):
+    expected_exception = test["expected_exception"]
+    compute_type = test["input"]["compute_type"]
+    compute_requirements = test["input"].get("compute_requirements")
+    if expected_exception:
+        with pytest.raises(expected_exception):
+            PipelineCreate(
+                name="pipe",
+                variables=[],
+                functions=[],
+                models=[],
+                graph_nodes=[],
+                outputs=[],
+                compute_type=compute_type,
+                compute_requirements=compute_requirements,
+            )
+
+    else:
+        schema = PipelineCreate(
+            name="pipe",
+            variables=[],
+            functions=[],
+            models=[],
+            graph_nodes=[],
+            outputs=[],
+            compute_type=compute_type,
+            compute_requirements=compute_requirements,
+        )
+        assert schema.compute_type == test["expected"]["compute_type"]
+        assert schema.compute_requirements == test["expected"]["compute_requirements"]

--- a/tests/test_pipeline_main.py
+++ b/tests/test_pipeline_main.py
@@ -48,27 +48,7 @@ def test_basic_pipeline():
     assert Pipeline._current_pipeline is None
 
 
-def test_pipeline_with_compute_requirements():
-    @pipeline_function
-    def add(f_1: float, f_2: float) -> float:
-        return f_1 + f_2
-
-    @pipeline_function
-    def square(f_1: float) -> float:
-        return f_1**2
-
-    with Pipeline("test", compute_type="gpu", min_gpu_vram_mb=4000) as my_pipeline:
-        in_1 = Variable(float, is_input=True)
-        in_2 = Variable(float, is_input=True)
-
-        my_pipeline.add_variables(in_1, in_2)
-
-        add_1 = add(in_1, in_2)
-        sq_1 = square(add_1)
-
-        my_pipeline.output(sq_1, add_1)
-
-    output_pipeline = Pipeline.get_pipeline("test")
-
-    assert output_pipeline.compute_type == "gpu"
-    assert output_pipeline.min_gpu_vram_mb == 4000
+def test_pipeline_with_compute_requirements(pipeline_graph_with_compute_requirements):
+    pipeline_graph = pipeline_graph_with_compute_requirements
+    assert pipeline_graph.compute_type == "gpu"
+    assert pipeline_graph.min_gpu_vram_mb == 4000


### PR DESCRIPTION
Allows users to specify the compute type (CPU/GPU) and additional GPU compute requirements at both a Pipeline and individual Run level.