### PR TITLE
Plutopulp/username validator update

### DIFF
--- a/pipeline/schemas/user.py
+++ b/pipeline/schemas/user.py
@@ -153,7 +153,7 @@ class UserCreate(UserBase):
 
     @validator("username")
     def validate_username(cls, value):
-        if not valid_username(value):
+        if value is not None and not valid_username(value):
             raise ValueError(
                 (
                     "must contain between 3-24 characters, "

--- a/tests/schemas/test_user.py
+++ b/tests/schemas/test_user.py
@@ -1,0 +1,9 @@
+from pipeline.schemas.user import UserCreate
+
+
+def test_user_create_optional_username():
+    none_username_payload = dict(
+        email="email@company.com", password="ExamplePass123", username=None
+    )
+    UserCreate(**none_username_payload)
+    assert True

--- a/tests/schemas/test_user.py
+++ b/tests/schemas/test_user.py
@@ -6,4 +6,3 @@ def test_user_create_optional_username():
         email="email@company.com", password="ExamplePass123", username=None
     )
     UserCreate(**none_username_payload)
-    assert True

--- a/tests/schemas/test_validators.py
+++ b/tests/schemas/test_validators.py
@@ -1,4 +1,4 @@
-from pipeline.schemas.validators import valid_password
+from pipeline.schemas.validators import valid_password, valid_username
 
 INVALID_PASSWORDS = [
     "askjhs",  # < 8 chars
@@ -14,12 +14,34 @@ VALID_PASSWORDS = [
     "''f^tTw3!dT={6_P)wSsFu_hcR:s6;De:6`_#6A!eKw//'exp9RAv.QdsVZ]fWWfxT!$tJST:7K",
 ]
 
+INVALID_USERNAMES = [
+    "as",  # < 3 chars
+    "assj" * 7,  # > 24 chars
+    "akljhak~!#ah",  # contains non-alphanumeric character which is neither "-" or "_"
+]
+
+VALID_USERNAMES = [
+    "asakiuy",  # > 3 chars
+    "ass6" * 6,  # <= 24 chars
+    "akljhak-ah82_",  # allowed special chars
+]
+
 
 def test_invalid_password():
     for password in INVALID_PASSWORDS:
-        assert valid_password(password) is False
+        assert not valid_password(password)
 
 
 def test_valid_password():
     for password in VALID_PASSWORDS:
-        assert valid_password(password) is True
+        assert valid_password(password)
+
+
+def test_invalid_usernames():
+    for username in INVALID_USERNAMES:
+        assert not valid_username(username)
+
+
+def test_valid_usernames():
+    for username in VALID_USERNAMES:
+        assert valid_username(username)


### PR DESCRIPTION
This PR fixes a bug in the `UserCreate` schemas' `username_validator`, which previously raised an error for usernames with the value of `None`. 
I had a scan through other validators to see if a similar issue was present, but didn't see any.
Note, the test seems a bit strange, there may be a better way of checking that optional usernames are in fact valid. If anyone has a better idea for a test, I'd appreciate your input. 