### PR TITLE
Refactor Pipeline model demo

### DIFF
--- a/examples/custom_models/model_from_base_class.py
+++ b/examples/custom_models/model_from_base_class.py
@@ -1,0 +1,57 @@
+##########
+#
+#   This example demonstrates how to load a '.pt' file with a Pipeline.
+#   It is generaliseable to use a PipelineFile in an arbitary way.
+#
+##########
+import getopt
+import sys
+from xml.parsers.expat import model
+import dill
+import cloudpickle
+
+from pipeline import (
+    Pipeline,
+    PipelineCloud,
+    PipelineFile,
+    Variable,
+    pipeline_function,
+    pipeline_model,
+)
+from pipeline.objects.decorators import PipelineBase
+
+
+class MyMatrixModel(PipelineBase):
+    @pipeline_function
+    def predict(self, x: list[float]) -> list[float]:
+        return x
+
+    @pipeline_function(run_once=True, on_startup=True)
+    def load(self) -> bool:
+        return True
+
+with Pipeline("Matrix pipeline") as pipeline:
+    input_list = Variable(type_class=list, is_input=True)
+
+    pipeline.add_variables(input_list)
+
+    # Note: When the pipeline is uploaded so are the weights.
+    # When the Pipeline is loaded on a worker the ".path" variable in the PipelineFile
+    # is not the local path any more but a path to the weights on the resource,
+    # when the file is loaded on the worker a path is created for it.
+
+    matrix_model = MyMatrixModel()
+
+    matrix_model.load()
+
+    output = matrix_model.predict(input_list)
+    pipeline.output(output)
+
+output_pipeline = Pipeline.get_pipeline("Matrix pipeline")
+# dill.detect.trace(True)
+# dill.dumps(output_pipeline)
+serialised = dill.dumps(output_pipeline)
+serialised = dill.loads(serialised)
+print(serialised.__dict__)
+print(output_pipeline.__dict__)
+breakpoint()

--- a/examples/custom_models/model_from_base_class.py
+++ b/examples/custom_models/model_from_base_class.py
@@ -4,19 +4,13 @@
 #   It is generaliseable to use a PipelineFile in an arbitary way.
 #
 ##########
-import getopt
-import sys
-from xml.parsers.expat import model
+
 import dill
-import cloudpickle
 
 from pipeline import (
     Pipeline,
-    PipelineCloud,
-    PipelineFile,
     Variable,
     pipeline_function,
-    pipeline_model,
 )
 from pipeline.objects.decorators import PipelineBase
 
@@ -48,10 +42,7 @@ with Pipeline("Matrix pipeline") as pipeline:
     pipeline.output(output)
 
 output_pipeline = Pipeline.get_pipeline("Matrix pipeline")
-# dill.detect.trace(True)
-# dill.dumps(output_pipeline)
 serialised = dill.dumps(output_pipeline)
 serialised = dill.loads(serialised)
 print(serialised.__dict__)
 print(output_pipeline.__dict__)
-breakpoint()

--- a/examples/custom_models/model_with_file.py
+++ b/examples/custom_models/model_with_file.py
@@ -6,6 +6,7 @@
 ##########
 import getopt
 import sys
+from pipeline.objects.decorators import PipelineBase
 
 import torch
 
@@ -15,17 +16,16 @@ from pipeline import (
     PipelineFile,
     Variable,
     pipeline_function,
-    pipeline_model,
 )
 from pipeline.util.torch_utils import tensor_to_list
 
 
-@pipeline_model
-class MyModel:
+class MyModel(PipelineBase):
 
     model: torch.nn.Module = None
 
-    def __init__(self):
+    def __init__(self, file_or_dir: str = None, compress_tar=False):
+        super().__init__(file_or_dir, compress_tar)
         self.my_model = torch.nn.Sequential(
             torch.nn.Linear(3, 5), torch.nn.Linear(5, 2)
         )

--- a/examples/custom_models/model_with_file_numpy.py
+++ b/examples/custom_models/model_with_file_numpy.py
@@ -6,7 +6,6 @@
 ##########
 import getopt
 import sys
-import dill
 
 import numpy as np
 

--- a/examples/custom_models/model_with_file_numpy.py
+++ b/examples/custom_models/model_with_file_numpy.py
@@ -6,6 +6,7 @@
 ##########
 import getopt
 import sys
+import dill
 
 import numpy as np
 
@@ -15,17 +16,12 @@ from pipeline import (
     PipelineFile,
     Variable,
     pipeline_function,
-    pipeline_model,
+    PipelineBase
 )
 
 
-@pipeline_model
-class MyMatrixModel:
-
+class MyMatrixModel(PipelineBase):
     matrix: np.ndarray = None
-
-    def __init__(self):
-        ...
 
     @pipeline_function
     def predict(self, x: list[float]) -> list[float]:
@@ -45,7 +41,7 @@ class MyMatrixModel:
         return True
 
 
-np.save("example_matrix.npy", np.random.rand(4, 7))
+np.save("example_matrix.npy", np.random.rand(3, 7))
 
 with Pipeline("Matrix pipeline") as pipeline:
     input_list = Variable(type_class=list, is_input=True)

--- a/pipeline/__init__.py
+++ b/pipeline/__init__.py
@@ -5,6 +5,7 @@ from pipeline.objects import (
     Variable,
     pipeline_function,
     pipeline_model,
+    PipelineBase
 )
 
 __all__ = [
@@ -14,4 +15,5 @@ __all__ = [
     "pipeline_function",
     "PipelineCloud",
     "PipelineFile",
+    "PipelineBase",
 ]

--- a/pipeline/objects/__init__.py
+++ b/pipeline/objects/__init__.py
@@ -4,6 +4,7 @@ from pipeline.objects.graph import Graph
 from pipeline.objects.model import Model
 from pipeline.objects.pipeline import Pipeline
 from pipeline.objects.variable import PipelineFile, Variable
+from pipeline.objects.decorators import PipelineBase
 
 __all__ = [
     "Pipeline",
@@ -14,4 +15,5 @@ __all__ = [
     "pipeline_function",
     "pipeline_model",
     "PipelineFile",
+    "PipelineBase",
 ]

--- a/pipeline/objects/decorators.py
+++ b/pipeline/objects/decorators.py
@@ -29,10 +29,8 @@ def pipeline_function(function=None, *, run_once=False, on_startup=False):
     @wraps(function)
     def execute_func(*args, **kwargs):
         if not Pipeline._pipeline_context_active:
-            print("wrapping out of context")
             return function(*args, **kwargs)
         else:
-            print("wrapping in context")
             function_ios = function.__annotations__
             if "return" not in function_ios:
                 raise Exception(
@@ -41,7 +39,6 @@ def pipeline_function(function=None, *, run_once=False, on_startup=False):
 
             processed_args: Variable = []
             for input_arg in args:
-                print(f"Input arg {input_arg} has type {type(input_arg)}")
                 if isinstance(input_arg, Variable):
                     processed_args.append(input_arg)
                 elif input_arg.__pipeline_model__:

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,32 +1,34 @@
-from pipeline.objects import Pipeline, Variable, pipeline_function, PipelineBase
-from pipeline.objects.decorators import PipelineBase
-
+import dill
+from pipeline.objects import Pipeline, Variable
 
 # Test basic Pipeline
-def test_with_exit():
-    class CustomModel(PipelineBase):
-        def __init__(self, model_path="", tokenizer_path="", file_or_dir: str = None, compress_tar=False):
-            super().__init__(file_or_dir, compress_tar)
-            
-            self.model_path = model_path
-            self.tokenizer_path = tokenizer_path
-
-        @pipeline_function
-        def predict(self, input: str, **kwargs: dict) -> str:
-            return input + " lol"
-
-        @pipeline_function
-        def load(self) -> None:
-            print("load")
+def test_with_exit(lol_model):
 
     with Pipeline("test") as my_pipeline:
         in_1 = Variable(str, is_input=True)
         my_pipeline.add_variable(in_1)
 
-        my_model = CustomModel()
+        my_model = lol_model()
         str_1 = my_model.predict(in_1)
 
         my_pipeline.output(str_1)
 
     output = Pipeline.run("test", "hey")
+    assert output == ["hey lol"]
+
+def test_model_pickle(lol_model):
+    with Pipeline("test") as my_pipeline:
+        in_1 = Variable(str, is_input=True)
+        my_pipeline.add_variable(in_1)
+
+        my_model = lol_model()
+        str_1 = my_model.predict(in_1)
+
+        my_pipeline.output(str_1)
+
+
+    output_pipeline = Pipeline.get_pipeline("test")
+    serialized_pipeline = dill.dumps(output_pipeline)
+    deserialized_pipeline = dill.loads(serialized_pipeline)
+    output = output_pipeline.run("hey")
     assert output == ["hey lol"]

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,11 +1,13 @@
-from pipeline.objects import Pipeline, Variable, pipeline_function, pipeline_model
+from pipeline.objects import Pipeline, Variable, pipeline_function, PipelineBase
+from pipeline.objects.decorators import PipelineBase
 
 
 # Test basic Pipeline
 def test_with_exit():
-    @pipeline_model()
-    class CustomModel:
-        def __init__(self, model_path="", tokenizer_path=""):
+    class CustomModel(PipelineBase):
+        def __init__(self, model_path="", tokenizer_path="", file_or_dir: str = None, compress_tar=False):
+            super().__init__(file_or_dir, compress_tar)
+            
             self.model_path = model_path
             self.tokenizer_path = tokenizer_path
 

--- a/tests/test_pipeline_main.py
+++ b/tests/test_pipeline_main.py
@@ -1,4 +1,4 @@
-from pipeline.objects import Pipeline, Variable, pipeline_function, pipeline_model
+from pipeline.objects import Pipeline, Variable, pipeline_function
 
 
 # Check if the decorator correctly uses __init__ and __enter__
@@ -54,23 +54,9 @@ def test_pipeline_with_compute_requirements(pipeline_graph_with_compute_requirem
     assert pipeline_graph.min_gpu_vram_mb == 4000
 
 
-def test_run_once():
-    @pipeline_model
-    class simple_model:
-        def __init__(self):
-            self.test_number = 0
-
-        @pipeline_function(run_once=True)
-        def run_once_func(self) -> int:
-            self.test_number += 1
-            return self.test_number
-
-        @pipeline_function
-        def get_number(self) -> int:
-            return self.test_number
-
+def test_run_once(run_once_model):
     with Pipeline("test") as builder:
-        my_simple_model = simple_model()
+        my_simple_model = run_once_model()
         my_simple_model.run_once_func()
         my_simple_model.run_once_func()
         output = my_simple_model.get_number()
@@ -81,23 +67,9 @@ def test_run_once():
     assert output_number == [1]
 
 
-def test_run_startup():
-    @pipeline_model
-    class simple_model:
-        def __init__(self):
-            self.test_number = 0
-
-        @pipeline_function(on_startup=True)
-        def run_startup_func(self) -> int:
-            self.test_number += 1
-            return self.test_number
-
-        @pipeline_function
-        def get_number(self) -> int:
-            return self.test_number
-
+def test_run_startup(on_startup_model):
     with Pipeline("test") as builder:
-        my_simple_model = simple_model()
+        my_simple_model = on_startup_model()
         output = my_simple_model.get_number()
         # The run_startup_func is called after the get_number in the pipeline,
         # but as a startup func it will actually be called before.

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -1,4 +1,9 @@
+from pickle import PicklingError
+
+import pytest
+
 from pipeline.objects.graph import Graph
+from pipeline.util import python_object_to_hex, hex_to_python_object
 from pipeline.schemas.pipeline import PipelineGet
 
 
@@ -19,3 +24,14 @@ def test_model_serialization(pickled_graph):
 
     # TODO Add actual run check
     assert reformed_graph.run("add lol")[0] == "add lol lol"
+
+
+def test_graph_serialisation(pipeline_graph):
+    try:
+        deserialized = hex_to_python_object(python_object_to_hex(pipeline_graph))
+        assert deserialized.__class__ == pipeline_graph.__class__
+        assert deserialized.run("add lol")[0] == "add lol lol"
+    except (PicklingError, AssertionError) as e:
+        pytest.fail(f"Pipeline Graph does not serialize: {e}")
+    except Exception as e:
+        pytest.fail(f"Unexpected error: {e}")

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -21,8 +21,6 @@ def test_model_serialization(pickled_graph):
         reformed_graph.nodes[0].function.class_instance
         == reformed_graph.models[0].model
     )
-
-    # TODO Add actual run check
     assert reformed_graph.run("add lol")[0] == "add lol lol"
 
 


### PR DESCRIPTION
A working example of how we could refactor our custom pipeline creation. The created class instance should be effectively the same as the one created with `@pipeline_model`. The only real difference to the user is that [if they want to create an init] they need to call `super().__init__(file_or_dir, compress_tar)` in their custom class init. 

Technically, this means that the required pipeline attributes are assigned to the model object at init and not by mutating the user defined class before it is created. I believe this is a cleaner solution and more 'pythonic'. This makes storing a reference to the parent class instance in a class' methods much more natural. I think the slight loss in simplicity is actually a benefit since its a lot more obvious for the end-user dev to understand what's going on.
Practically, this moves the model options to instance creation rather than class creation (this is related to not directly mutating the user created class).