### PR TITLE
Direct PipelineFile uploads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,4 +136,4 @@ local/
 pipeline-bak/
 *.env
 
-•.DS_Store
+.DS_Store

--- a/pipeline/api/cloud.py
+++ b/pipeline/api/cloud.py
@@ -28,13 +28,13 @@ from pipeline.schemas.pipeline import (
     PipelineVariableGet,
 )
 from pipeline.schemas.pipeline_file import (
+    MultipartUploadMetadata,
     PipelineFileDirectUploadFinaliseCreate,
     PipelineFileDirectUploadInitCreate,
     PipelineFileDirectUploadInitGet,
     PipelineFileDirectUploadPartCreate,
     PipelineFileDirectUploadPartGet,
     PipelineFileGet,
-    MultipartUploadMetadata,
 )
 from pipeline.schemas.run import RunCreate
 from pipeline.util import (

--- a/pipeline/api/cloud.py
+++ b/pipeline/api/cloud.py
@@ -159,10 +159,12 @@ class PipelineCloud:
         - Then we upload the file directly using the given URL
         """
 
+        # TODO - check we always want to generate a new ID
+        file_name = generate_id(20)
         file_hash = self._hash_file(pipeline_file.path)
         file_size = os.path.getsize(pipeline_file.path)
         direct_upload_schema = FileDirectUploadCreate(
-            file_hash=file_hash, file_size=file_size
+            name=file_name, file_hash=file_hash, file_size=file_size
         )
         response = self._post("/v2/files/presigned-url", direct_upload_schema.dict())
         direct_upload_get = FileDirectUploadGet.parse_obj(response)

--- a/pipeline/api/cloud.py
+++ b/pipeline/api/cloud.py
@@ -168,6 +168,16 @@ class PipelineCloud:
         )
         response = self._post("/v2/files/presigned-url", direct_upload_schema.dict())
         direct_upload_get = FileDirectUploadGet.parse_obj(response)
+
+        # upload file
+        # TODO - optimise for large files
+        with open(pipeline_file.path, "rb") as f:
+            files = {"file": (direct_upload_get.file_id, f)}
+            http_response = requests.post(
+                direct_upload_get.upload_url,
+                data=direct_upload_get.upload_fields,
+                files=files,
+            )
         # # file = self.upload_file(pipeline_file.path, "/")
         # return PipelineFileVariableGet(
         #     path=pipeline_file.path, file=file, hash=file_hash

--- a/pipeline/api/cloud.py
+++ b/pipeline/api/cloud.py
@@ -34,6 +34,7 @@ from pipeline.schemas.pipeline_file import (
     PipelineFileDirectUploadPartCreate,
     PipelineFileDirectUploadPartGet,
     PipelineFileGet,
+    MultipartUploadMetadata,
 )
 from pipeline.schemas.run import RunCreate
 from pipeline.util import (
@@ -166,7 +167,7 @@ class PipelineCloud:
 
     def _direct_upload_pipeline_file_chunk(
         self, data: bytes, pipeline_file_id: str, part_num: int
-    ) -> dict:
+    ) -> MultipartUploadMetadata:
         """Upload a single chunk of a multi-part pipeline file upload.
 
         Returns the metadata associated with this upload (this is needed to pass into
@@ -185,10 +186,10 @@ class PipelineCloud:
         data = data.hex().encode()
         response = requests.put(part_upload_get.upload_url, data=data)
         etag = response.headers["ETag"]
-        return {"ETag": etag, "PartNumber": part_num}
+        return MultipartUploadMetadata(ETag=etag, PartNumber=part_num)
 
     def _finalise_direct_pipeline_file_upload(
-        self, pipeline_file_id: str, multipart_metadata: List[dict]
+        self, pipeline_file_id: str, multipart_metadata: List[MultipartUploadMetadata]
     ) -> PipelineFileGet:
         """Finalise the direct multi-part pipeline file upload"""
         finalise_upload_schema = PipelineFileDirectUploadFinaliseCreate(

--- a/pipeline/api/cloud.py
+++ b/pipeline/api/cloud.py
@@ -188,6 +188,8 @@ class PipelineCloud:
                 file_data = f.read(FILE_CHUNK_SIZE)
                 if not file_data:
                     break
+                # convert data to hex
+                file_data = file_data.hex().encode()
                 # get presigned URL
                 part_num = len(parts) + 1
                 # TODO - remove

--- a/pipeline/api/cloud.py
+++ b/pipeline/api/cloud.py
@@ -232,7 +232,6 @@ class PipelineCloud:
                     progress.close()
                     break
 
-                progress.update(len(file_data))
                 part_num = len(parts) + 1
 
                 upload_metadata = self._direct_upload_file_chunk(
@@ -242,6 +241,7 @@ class PipelineCloud:
                     part_num=part_num,
                 )
                 parts.append(upload_metadata)
+                progress.update(len(file_data))
 
         file = self._finalise_direct_file_upload(
             upload_id=upload_id, file_id=file_id, multipart_metadata=parts

--- a/pipeline/schemas/file.py
+++ b/pipeline/schemas/file.py
@@ -23,13 +23,21 @@ class FileCreate(FileBase):
     file_bytes: Optional[str]
 
 
-class FileDirectUploadCreate(FileBase):
-    file_hash: Optional[str]
+class FileDirectUploadInitCreate(FileBase):
     file_size: int
 
 
-class FileDirectUploadGet(BaseModel):
+class FileDirectUploadInitGet(BaseModel):
     upload_id: str
     file_id: str
-    # upload_fields: dict
-    # url_expiry_time: datetime
+
+
+class FileDirectUploadPartCreate(BaseModel):
+    upload_id: str
+    file_id: str
+    part_num: int
+
+
+class FileDirectUploadPartGet(BaseModel):
+    upload_url: str
+    url_expiry_time: datetime

--- a/pipeline/schemas/file.py
+++ b/pipeline/schemas/file.py
@@ -1,6 +1,4 @@
-from typing import Optional
-
-from datetime import datetime
+from typing import List, Optional
 
 from .base import BaseModel
 
@@ -46,4 +44,4 @@ class FileDirectUploadPartGet(BaseModel):
 class FileDirectUploadFinaliseCreate(BaseModel):
     upload_id: str
     file_id: str
-    multipart_metadata: dict
+    multipart_metadata: List[dict]

--- a/pipeline/schemas/file.py
+++ b/pipeline/schemas/file.py
@@ -40,4 +40,4 @@ class FileDirectUploadPartCreate(BaseModel):
 
 class FileDirectUploadPartGet(BaseModel):
     upload_url: str
-    url_expiry_time: datetime
+    # url_expiry_time: datetime

--- a/pipeline/schemas/file.py
+++ b/pipeline/schemas/file.py
@@ -30,5 +30,6 @@ class FileDirectUploadCreate(FileBase):
 
 class FileDirectUploadGet(BaseModel):
     upload_url: str
+    upload_fields: dict
     url_expiry_time: datetime
     file_id: str

--- a/pipeline/schemas/file.py
+++ b/pipeline/schemas/file.py
@@ -1,5 +1,7 @@
 from typing import Optional
 
+from datetime import datetime
+
 from .base import BaseModel
 
 
@@ -19,3 +21,14 @@ class FileGet(FileBase):
 class FileCreate(FileBase):
     name: Optional[str]
     file_bytes: Optional[str]
+
+
+class FileDirectUploadCreate(FileBase):
+    file_hash: Optional[str]
+    file_size: int
+
+
+class FileDirectUploadGet(BaseModel):
+    upload_url: str
+    url_expiry_time: datetime
+    file_id: str

--- a/pipeline/schemas/file.py
+++ b/pipeline/schemas/file.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import Optional
 
 from .base import BaseModel
 
@@ -19,33 +19,3 @@ class FileGet(FileBase):
 class FileCreate(FileBase):
     name: Optional[str]
     file_bytes: Optional[str]
-
-
-class MultiPartDirectFileUpload(BaseModel):
-    """Base class for multipart direct file uploads"""
-
-    upload_id: str
-    file_id: str
-
-
-class FileDirectUploadInitCreate(FileBase):
-    file_size: int
-
-
-class FileDirectUploadInitGet(MultiPartDirectFileUpload):
-    pass
-
-
-class FileDirectUploadPartCreate(MultiPartDirectFileUpload):
-    # The part number for this multi-part file upload
-    part_num: int
-
-
-class FileDirectUploadPartGet(BaseModel):
-    # The URL to use when uploading the fie
-    upload_url: str
-
-
-class FileDirectUploadFinaliseCreate(MultiPartDirectFileUpload):
-    # The metadata obtained from each part of the file upload
-    multipart_metadata: List[dict]

--- a/pipeline/schemas/file.py
+++ b/pipeline/schemas/file.py
@@ -12,7 +12,7 @@ class FileGet(FileBase):
     path: str
     #: The data as hex-encoded bytes, if the data size is less than 20 kB
     data: Optional[str]
-    #: The data size in kilobytes (kB)
+    #: The data size in bytes
     file_size: int
 
 
@@ -21,27 +21,31 @@ class FileCreate(FileBase):
     file_bytes: Optional[str]
 
 
+class MultiPartDirectFileUpload(BaseModel):
+    """Base class for multipart direct file uploads"""
+
+    upload_id: str
+    file_id: str
+
+
 class FileDirectUploadInitCreate(FileBase):
     file_size: int
 
 
-class FileDirectUploadInitGet(BaseModel):
-    upload_id: str
-    file_id: str
+class FileDirectUploadInitGet(MultiPartDirectFileUpload):
+    pass
 
 
-class FileDirectUploadPartCreate(BaseModel):
-    upload_id: str
-    file_id: str
+class FileDirectUploadPartCreate(MultiPartDirectFileUpload):
+    # The part number for this multi-part file upload
     part_num: int
 
 
 class FileDirectUploadPartGet(BaseModel):
+    # The URL to use when uploading the fie
     upload_url: str
-    # url_expiry_time: datetime
 
 
-class FileDirectUploadFinaliseCreate(BaseModel):
-    upload_id: str
-    file_id: str
+class FileDirectUploadFinaliseCreate(MultiPartDirectFileUpload):
+    # The metadata obtained from each part of the file upload
     multipart_metadata: List[dict]

--- a/pipeline/schemas/file.py
+++ b/pipeline/schemas/file.py
@@ -41,3 +41,9 @@ class FileDirectUploadPartCreate(BaseModel):
 class FileDirectUploadPartGet(BaseModel):
     upload_url: str
     # url_expiry_time: datetime
+
+
+class FileDirectUploadFinaliseCreate(BaseModel):
+    upload_id: str
+    file_id: str
+    multipart_metadata: dict

--- a/pipeline/schemas/file.py
+++ b/pipeline/schemas/file.py
@@ -30,6 +30,7 @@ class FileDirectUploadCreate(FileBase):
 
 class FileDirectUploadGet(BaseModel):
     upload_id: str
+    path: str
     # upload_fields: dict
     # url_expiry_time: datetime
     # file_id: str

--- a/pipeline/schemas/file.py
+++ b/pipeline/schemas/file.py
@@ -29,7 +29,7 @@ class FileDirectUploadCreate(FileBase):
 
 
 class FileDirectUploadGet(BaseModel):
-    upload_url: str
-    upload_fields: dict
-    url_expiry_time: datetime
-    file_id: str
+    upload_id: str
+    # upload_fields: dict
+    # url_expiry_time: datetime
+    # file_id: str

--- a/pipeline/schemas/file.py
+++ b/pipeline/schemas/file.py
@@ -30,7 +30,6 @@ class FileDirectUploadCreate(FileBase):
 
 class FileDirectUploadGet(BaseModel):
     upload_id: str
-    path: str
+    file_id: str
     # upload_fields: dict
     # url_expiry_time: datetime
-    # file_id: str

--- a/pipeline/schemas/pipeline_file.py
+++ b/pipeline/schemas/pipeline_file.py
@@ -23,10 +23,20 @@ class PipelineFileDirectUploadPartGet(BaseModel):
     upload_url: str
 
 
+class MultipartUploadMetadata(BaseModel):
+    """Schema for multi-part uploads direct to storage server.
+
+    (We don't have any control over this schema)
+    """
+
+    ETag: str
+    PartNumber: int
+
+
 class PipelineFileDirectUploadFinaliseCreate(BaseModel):
     pipeline_file_id: str
     # The metadata obtained from each part of the file upload
-    multipart_metadata: List[dict]
+    multipart_metadata: List[MultipartUploadMetadata]
 
 
 class PipelineFileGet(BaseModel):

--- a/pipeline/schemas/pipeline_file.py
+++ b/pipeline/schemas/pipeline_file.py
@@ -1,0 +1,35 @@
+from typing import List
+
+from .base import BaseModel
+from .file import FileGet
+
+
+class PipelineFileDirectUploadInitCreate(BaseModel):
+    file_size: int
+
+
+class PipelineFileDirectUploadInitGet(BaseModel):
+    pipeline_file_id: str
+
+
+class PipelineFileDirectUploadPartCreate(BaseModel):
+    pipeline_file_id: str
+    # The part number for this multi-part file upload
+    part_num: int
+
+
+class PipelineFileDirectUploadPartGet(BaseModel):
+    # The URL to use when uploading the fie
+    upload_url: str
+
+
+class PipelineFileDirectUploadFinaliseCreate(BaseModel):
+    pipeline_file_id: str
+    # The metadata obtained from each part of the file upload
+    multipart_metadata: List[dict]
+
+
+class PipelineFileGet(BaseModel):
+    id: str
+    name: str
+    hex_file: FileGet

--- a/pipeline/util/logging.py
+++ b/pipeline/util/logging.py
@@ -19,6 +19,7 @@ class bcolors:
 
 levels = {"WARNING": bcolors.ORANGE, "INFO": bcolors.PURPLE, "ERROR": bcolors.FAIL}
 PIPELINE_STR = f"{bcolors.OKBLUE}Pipeline{bcolors.ENDC}"
+PIPELINE_FILE_STR = f"{bcolors.OKBLUE}PipelineFile{bcolors.ENDC}"
 
 
 def _print(val, level="INFO"):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pipeline-ai"
-version = "0.0.41"
+version = "0.0.42"
 description = "Pipelines for machine learning workloads."
 authors = [
   "Paul Hetherington <ph@mystic.ai>",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,16 +15,14 @@ from pipeline.objects import (
     pipeline_model,
 )
 from pipeline.schemas.data import DataGet
-from pipeline.schemas.file import (
-    FileDirectUploadFinaliseCreate,
-    FileDirectUploadInitCreate,
-    FileDirectUploadInitGet,
-    FileDirectUploadPartCreate,
-    FileDirectUploadPartGet,
-    FileGet,
-)
+from pipeline.schemas.file import FileGet
 from pipeline.schemas.function import FunctionGet
 from pipeline.schemas.model import ModelGet
+from pipeline.schemas.pipeline_file import (
+    PipelineFileDirectUploadInitGet,
+    PipelineFileDirectUploadPartGet,
+    PipelineFileGet,
+)
 from pipeline.schemas.project import ProjectGet
 from pipeline.schemas.runnable import RunnableType
 from pipeline.util import python_object_to_hex
@@ -49,10 +47,10 @@ def api_response(
     function_get_json,
     model_get_json,
     data_get_json,
-    file_direct_upload_init_get_json,
-    file_direct_upload_part_get_json,
+    pipeline_file_direct_upload_init_get_json,
+    pipeline_file_direct_upload_part_get_json,
     presigned_url,
-    finalise_direct_file_upload_get_json,
+    finalise_direct_pipeline_file_upload_get_json,
 ):
     function_get_id = function_get_json["id"]
     model_get_id = model_get_json["id"]
@@ -102,22 +100,21 @@ def api_response(
         )
         rsps.add(
             responses.POST,
-            url + "/v2/files/initiate-multipart-upload",
-            json=file_direct_upload_init_get_json,
+            url + "/v2/pipeline-files/initiate-multipart-upload",
+            json=pipeline_file_direct_upload_init_get_json,
             status=200,
             match=[matchers.header_matcher({"Authorization": "Bearer " + token})],
         )
         rsps.add(
             responses.POST,
-            url + "/v2/files/presigned-url",
-            json=file_direct_upload_part_get_json,
+            url + "/v2/pipeline-files/presigned-url",
+            json=pipeline_file_direct_upload_part_get_json,
             status=200,
             match=[
                 matchers.header_matcher({"Authorization": "Bearer " + token}),
                 matchers.json_params_matcher(
                     {
-                        "file_id": "dummy_file_id",
-                        "upload_id": "dummy_upload_id",
+                        "pipeline_file_id": "pipeline_file_id",
                         "part_num": 1,
                     }
                 ),
@@ -129,15 +126,14 @@ def api_response(
         )
         rsps.add(
             responses.POST,
-            url + "/v2/files/finalise-multipart-upload",
-            json=finalise_direct_file_upload_get_json,
+            url + "/v2/pipeline-files/finalise-multipart-upload",
+            json=finalise_direct_pipeline_file_upload_get_json,
             status=200,
             match=[
                 matchers.header_matcher({"Authorization": "Bearer " + token}),
                 matchers.json_params_matcher(
                     {
-                        "file_id": "dummy_file_id",
-                        "upload_id": "dummy_upload_id",
+                        "pipeline_file_id": "pipeline_file_id",
                         "multipart_metadata": [{"ETag": "dummy_etag", "PartNumber": 1}],
                     }
                 ),
@@ -257,10 +253,8 @@ def data_get_json(data_get, file_get_json):
 
 
 @pytest.fixture()
-def file_direct_upload_init_get_json():
-    return FileDirectUploadInitGet(
-        upload_id="dummy_upload_id", file_id="dummy_file_id"
-    ).dict()
+def pipeline_file_direct_upload_init_get_json():
+    return PipelineFileDirectUploadInitGet(pipeline_file_id="pipeline_file_id").dict()
 
 
 @pytest.fixture()
@@ -269,18 +263,22 @@ def presigned_url():
 
 
 @pytest.fixture()
-def file_direct_upload_part_get_json(presigned_url):
-    return FileDirectUploadPartGet(upload_url=presigned_url).dict()
+def pipeline_file_direct_upload_part_get_json(presigned_url):
+    return PipelineFileDirectUploadPartGet(upload_url=presigned_url).dict()
 
 
 @pytest.fixture()
-def finalise_direct_file_upload_get_json():
-    return FileGet(
-        name="test",
-        id="dummy_file_id",
-        path="test/path/to/file",
-        data="dummy_data",
-        file_size=10,
+def finalise_direct_pipeline_file_upload_get_json():
+    return PipelineFileGet(
+        id="pipeline_file_id",
+        name="pipeline_file_id",
+        hex_file=FileGet(
+            name="pipeline_file_id",
+            id="dummy_file_id",
+            path="pipeline_file_id",
+            data="dummy_data",
+            file_size=10,
+        ),
     ).dict()
 
 

--- a/tests/test_pipeline_cloud.py
+++ b/tests/test_pipeline_cloud.py
@@ -52,3 +52,13 @@ def test_cloud_download_data(url, token, data_get, file_get):
     api = PipelineCloud(url, token)
     d = api.download_data(data_get.id)
     assert d() == hex_to_python_object(file_get.data)()
+
+
+@pytest.mark.usefixtures("api_response")
+def test_cloud_upload_pipeline_file(
+    url, token, pipeline_file, file, finalise_direct_file_upload_get_json
+):
+    api = PipelineCloud(url, token)
+    pipeline_file_var_get = api.upload_pipeline_file(pipeline_file)
+    assert pipeline_file_var_get.path == str(file)
+    assert pipeline_file_var_get.file.dict() == finalise_direct_file_upload_get_json

--- a/tests/test_pipeline_cloud.py
+++ b/tests/test_pipeline_cloud.py
@@ -56,9 +56,12 @@ def test_cloud_download_data(url, token, data_get, file_get):
 
 @pytest.mark.usefixtures("api_response")
 def test_cloud_upload_pipeline_file(
-    url, token, pipeline_file, file, finalise_direct_file_upload_get_json
+    url, token, pipeline_file, file, finalise_direct_pipeline_file_upload_get_json
 ):
     api = PipelineCloud(url, token)
     pipeline_file_var_get = api.upload_pipeline_file(pipeline_file)
     assert pipeline_file_var_get.path == str(file)
-    assert pipeline_file_var_get.file.dict() == finalise_direct_file_upload_get_json
+    assert (
+        pipeline_file_var_get.file.dict()
+        == finalise_direct_pipeline_file_upload_get_json["hex_file"]
+    )


### PR DESCRIPTION
Allow client to upload files directly. This is needed for `PipelineFile`s which can be very large.

TODO:
- [x] Add tests