### PR TITLE
[BE-213] Refactor RunGet schema

### DIFF
--- a/pipeline/schemas/run.py
+++ b/pipeline/schemas/run.py
@@ -72,21 +72,24 @@ class RunIOGet(RunnableIOGet):
     data_url: str
 
 
-class RunGet(BaseModel):
+class RunGetBrief(BaseModel):
     id: str
+    compute_time_ms: Optional[int]
+    result_preview: Optional[Union[list, dict]]
+    result: Optional[FileGet]
+    error: Optional[RunError]
+
+
+class RunGet(RunGetBrief):
     created_at: datetime.datetime
     started_at: Optional[datetime.datetime]
     ended_at: Optional[datetime.datetime]
     run_state: RunState
     resource_type: Optional[str]
-    compute_time_ms: Optional[int]
     runnable: Union[FunctionGet, PipelineGet]
     data: DataGet
     blocking: Optional[bool] = False
-    result: Optional[FileGet]
     #: JSON-serialised runnable return value, if available
-    result_preview: Optional[Union[list, dict]]
-    error: Optional[RunError]
     compute_requirements: Optional[ComputeRequirements] = None
 
     class Config:


### PR DESCRIPTION
Currently, the response the user get to an `api.run_pipeline(...)` call is extremely bloated. This is because the returned object is very similar to the object returned from the cluster. I.e it contains a lot of information which is useful internally but useless to the user. Here I propose creating a new schema, `RunGetBrief` that is instead returned to the user. Its fields are up for negotiation. For example, do we always try to return a result preview alongside a result file id? Currently, if the result is >1MB then the `result_preview` field is `null`. This is not ergonomic and means that if an end user is expecting file sizes larger and smaller than 1MB they would have to check each one of their responses for a result preview. If one is not returned then they would have to retrieve it themselves. This could be easily implemented in the python library's `api.run_pipeline(...)` and If this is thoroughly documented it could be a passable situation for pure http request users.

The fields that are omitted by `RunGetBrief` (and more) can be fetched from the `/v2/runs/<run_id>` for users requiring this information.