### PR TITLE
Fix to getting source code from inspect in notebooks

### DIFF
--- a/pipeline/objects/function.py
+++ b/pipeline/objects/function.py
@@ -1,3 +1,5 @@
+import uuid
+
 import inspect
 from hashlib import sha256
 from typing import Any, Callable, Dict, Optional
@@ -29,7 +31,10 @@ class Function:
         self.class_instance = class_instance
         self.function = function
 
-        self.source = inspect.getsource(function)
+        try:
+            self.source = inspect.getsource(function)
+        except:
+            self.source = str(uuid.uuid4())
         self.hash = sha256(self.source.encode()).hexdigest()
 
         # TODO: Add verification that all inputs to function have a typing annotation,

--- a/pipeline/objects/function.py
+++ b/pipeline/objects/function.py
@@ -1,6 +1,5 @@
-import uuid
-
 import inspect
+import uuid
 from hashlib import sha256
 from typing import Any, Callable, Dict, Optional
 

--- a/pipeline/objects/function.py
+++ b/pipeline/objects/function.py
@@ -32,7 +32,7 @@ class Function:
 
         try:
             self.source = inspect.getsource(function)
-        except OSError as e:
+        except OSError:
             self.source = str(uuid.uuid4())
         self.hash = sha256(self.source.encode()).hexdigest()
 

--- a/pipeline/objects/function.py
+++ b/pipeline/objects/function.py
@@ -33,7 +33,7 @@ class Function:
 
         try:
             self.source = inspect.getsource(function)
-        except:
+        except OSError as e:
             self.source = str(uuid.uuid4())
         self.hash = sha256(self.source.encode()).hexdigest()
 

--- a/pipeline/objects/model.py
+++ b/pipeline/objects/model.py
@@ -20,7 +20,10 @@ class Model:
 
         self.name = name
         self.model = model
-        self.source = inspect.getsource(model.__class__)
+        try:
+            self.source = inspect.getsource(model.__class__)
+        except:
+            self.source = "-"
         self.hash = sha256(self.source.encode()).hexdigest()
         self.local_id = generate_id(10) if local_id is None else local_id
         if not hasattr(self.model, "local_id"):

--- a/pipeline/objects/model.py
+++ b/pipeline/objects/model.py
@@ -1,3 +1,5 @@
+import uuid
+
 import inspect
 from hashlib import sha256
 from typing import Any
@@ -23,7 +25,8 @@ class Model:
         try:
             self.source = inspect.getsource(model.__class__)
         except:
-            self.source = "-"
+            self.source = str(uuid.uuid4())
+
         self.hash = sha256(self.source.encode()).hexdigest()
         self.local_id = generate_id(10) if local_id is None else local_id
         if not hasattr(self.model, "local_id"):

--- a/pipeline/objects/model.py
+++ b/pipeline/objects/model.py
@@ -24,7 +24,7 @@ class Model:
         self.model = model
         try:
             self.source = inspect.getsource(model.__class__)
-        except:
+        except OSError as e:
             self.source = str(uuid.uuid4())
 
         self.hash = sha256(self.source.encode()).hexdigest()

--- a/pipeline/objects/model.py
+++ b/pipeline/objects/model.py
@@ -23,7 +23,7 @@ class Model:
         self.model = model
         try:
             self.source = inspect.getsource(model.__class__)
-        except OSError as e:
+        except OSError:
             self.source = str(uuid.uuid4())
 
         self.hash = sha256(self.source.encode()).hexdigest()

--- a/pipeline/objects/model.py
+++ b/pipeline/objects/model.py
@@ -1,6 +1,5 @@
-import uuid
-
 import inspect
+import uuid
 from hashlib import sha256
 from typing import Any
 


### PR DESCRIPTION
Notebook environments aren't always compatible with the `inspect.getsource(...)` function. When this is the case we now record a random UUID so that the hash generated for the model is random.