### PR TITLE
Remove conflicting setuptools version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,6 @@ cloudpickle = "^2.1.0"
 dill = "^0.3.4"
 
 [tool.poetry.dev-dependencies]
-setuptools = "^59.2.0"
 pydantic = "^1.8.2"
 requests = "^2.26.0"
 pyhumps = "^3.0.2"


### PR DESCRIPTION
Conflicts with [the other setuptools dependency](https://github.com/mystic-ai/pipeline/blob/8e0c961d186a0d782d2da5d8d9017f11aad4d3d6/pyproject.toml#L23).