### PR TITLE
Oscar/add_io_file_descriptor

### DIFF
--- a/pipeline/io.py
+++ b/pipeline/io.py
@@ -33,8 +33,8 @@ class File():
         file_ext = file_as_str_with_extension[file_as_str_with_extension.find(self.key)+len(self.key):file_as_str_with_extension.rfind(self.key)]
         return cleaned_string, file_ext
 
-    def file_str_to_b64(self) -> Union[bytes, list]:
-        cleaned_str, file_ext = self._remove_ext_from_string()
+    def file_str_to_b64(self, file_as_str_with_extension: str) -> Union[bytes, list]:
+        cleaned_str, file_ext = self._remove_ext_from_string(file_as_str_with_extension)
         file_as_b64 = base64.decodebytes(cleaned_str.encode())
         return file_as_b64, file_ext
     

--- a/pipeline/io.py
+++ b/pipeline/io.py
@@ -1,0 +1,45 @@
+import base64
+from typing import Union
+
+class File():
+    def __init__(self, path: str) -> None:
+        self.path = path
+        self._key = "ext_file" # Used to append the extension to the file string and extract it during pipeline execution
+        pass
+
+    def _file_to_str_with_extension(self, file_path: str) -> str:
+        ''' 
+        Convert a file to a string so that it can be sent over the API. The file extension is extracted and appended to string.
+
+        Args:
+            file_path: Path to file to be sent over the API. 
+        Returns:
+            File as string + extension appended
+        '''
+        with open(file_path, 'rb') as f:
+            return base64.b64encode(f.read()).decode() + f'{self._key}{file_path[file_path.rfind("."):]}{self._key}'
+
+    def _remove_ext_from_string(self, file_as_str_with_extension: str) -> str:
+        '''
+        Removes the extension from the string
+
+        Args:
+            file_as_str_with_extension: File as string with the extension appended
+        Returns:
+            cleaned_string: File as string without the extension
+            file_ext: Extension from file
+        '''
+        cleaned_string = file_as_str_with_extension[:file_as_str_with_extension.find(self.key)]
+        file_ext = file_as_str_with_extension[file_as_str_with_extension.find(self.key)+len(self.key):file_as_str_with_extension.rfind(self.key)]
+        return cleaned_string, file_ext
+
+    def file_str_to_b64(self) -> Union[bytes, list]:
+        cleaned_str, file_ext = self._remove_ext_from_string()
+        file_as_b64 = base64.decodebytes(cleaned_str.encode())
+        return file_as_b64, file_ext
+    
+    def to_api(self) -> str:
+        '''
+        Provides a unified method to send io objects across the API. This should be the last stage before passing the desired object to the api.run() function.
+        '''
+        return self._file_to_str_with_extension(self.path)

--- a/pipeline/io.py
+++ b/pipeline/io.py
@@ -1,8 +1,9 @@
 import base64
+from pickle import NONE
 from typing import Union
 
 class File():
-    def __init__(self, path: str) -> None:
+    def __init__(self, path: str = None) -> None:
         self.path = path
         self._key = "ext_file" # Used to append the extension to the file string and extract it during pipeline execution
         pass

--- a/pipeline/io.py
+++ b/pipeline/io.py
@@ -30,8 +30,8 @@ class File():
             cleaned_string: File as string without the extension
             file_ext: Extension from file
         '''
-        cleaned_string = file_as_str_with_extension[:file_as_str_with_extension.find(self.key)]
-        file_ext = file_as_str_with_extension[file_as_str_with_extension.find(self.key)+len(self.key):file_as_str_with_extension.rfind(self.key)]
+        cleaned_string = file_as_str_with_extension[:file_as_str_with_extension.find(self._key)]
+        file_ext = file_as_str_with_extension[file_as_str_with_extension.find(self._key)+len(self._key):file_as_str_with_extension.rfind(self._key)]
         return cleaned_string, file_ext
 
     def file_str_to_b64(self, file_as_str_with_extension: str) -> Union[bytes, list]:

--- a/pipeline/io.py
+++ b/pipeline/io.py
@@ -1,11 +1,46 @@
 import base64
-from pickle import NONE
-from typing import Union
 
 class File():
+    """
+    IO file descriptor. Allows to manipulate files between client and server.
+
+    Example: (Transfer an audio file)
+
+        '''
+        On client
+        '''
+
+        from pipeline.io import File
+
+        FILE_PATH = "files/audio.flac"
+
+        # Convert file into a string
+        input_data = File(FILE_PATH).to_api()
+
+        run = client.run_pipeline("pipeline_ID", [input_data])
+
+        '''
+        On server
+        '''
+        from pipeline.io import File
+        import tempfile
+
+        file = File()
+        file_as_bytes = file.file_get_bytes(input_data)
+        temp_file = tempfile.NamedTemporaryFile(delete=True, mode="wb", suffix=file.extension, dir="")
+        temp_file.write(file_as_bytes)
+
+        # Do whatever to the file
+        # ...
+        # Close and delete file
+        temp_file.close()
+
+
+    """
     def __init__(self, path: str = None) -> None:
         self.path = path
         self._key = "ext_file" # Used to append the extension to the file string and extract it during pipeline execution
+        self.extension = None
         pass
 
     def _file_to_str_with_extension(self, file_path: str) -> str:
@@ -22,25 +57,33 @@ class File():
 
     def _remove_ext_from_string(self, file_as_str_with_extension: str) -> str:
         '''
-        Removes the extension from the string
+        Removes the extension from the string.
 
         Args:
             file_as_str_with_extension: File as string with the extension appended
         Returns:
             cleaned_string: File as string without the extension
-            file_ext: Extension from file
         '''
         cleaned_string = file_as_str_with_extension[:file_as_str_with_extension.find(self._key)]
-        file_ext = file_as_str_with_extension[file_as_str_with_extension.find(self._key)+len(self._key):file_as_str_with_extension.rfind(self._key)]
-        return cleaned_string, file_ext
+        self.extension = file_as_str_with_extension[file_as_str_with_extension.find(self._key)+len(self._key):file_as_str_with_extension.rfind(self._key)]
+        return cleaned_string
 
-    def file_str_to_b64(self, file_as_str_with_extension: str) -> Union[bytes, list]:
-        cleaned_str, file_ext = self._remove_ext_from_string(file_as_str_with_extension)
-        file_as_b64 = base64.decodebytes(cleaned_str.encode())
-        return file_as_b64, file_ext
+    def file_get_bytes(self, file_as_str_with_extension: str) -> bytes:
+        '''
+        Use this method to manipulate the sent file. 
+        The output of this function is the final form of the file and can be directly read and manipulated or written into another file.
+
+        Args:
+            file_as_str_with_extension: File in string format as sent via the API. Includes the extension of the source file.
+        Return:
+            file_as_bytes: Bytes representation of the file. 
+        '''
+        cleaned_str = self._remove_ext_from_string(file_as_str_with_extension)
+        file_as_bytes = base64.decodebytes(cleaned_str.encode())
+        return file_as_bytes
     
     def to_api(self) -> str:
         '''
-        Provides a unified method to send io objects across the API. This should be the last stage before passing the desired object to the api.run() function.
+        Provides a unified method to send io objects across the API. This should be the last stage before passing the desired object to api.run() function.
         '''
         return self._file_to_str_with_extension(self.path)

--- a/pipeline/io.py
+++ b/pipeline/io.py
@@ -1,6 +1,7 @@
 import base64
 
-class File():
+
+class File:
     """
     IO file descriptor. Allows to manipulate files between client and server.
 
@@ -37,53 +38,62 @@ class File():
 
 
     """
+
     def __init__(self, path: str = None) -> None:
         self.path = path
-        self._key = "ext_file" # Used to append the extension to the file string and extract it during pipeline execution
+        self._key = "ext_file"  # Used to append the extension to the file string and extract it during pipeline execution
         self.extension = None
         pass
 
     def _file_to_str_with_extension(self, file_path: str) -> str:
-        ''' 
+        """
         Convert a file to a string so that it can be sent over the API. The file extension is extracted and appended to string.
 
         Args:
-            file_path: Path to file to be sent over the API. 
+            file_path: Path to file to be sent over the API.
         Returns:
             File as string + extension appended
-        '''
-        with open(file_path, 'rb') as f:
-            return base64.b64encode(f.read()).decode() + f'{self._key}{file_path[file_path.rfind("."):]}{self._key}'
+        """
+        with open(file_path, "rb") as f:
+            return (
+                base64.b64encode(f.read()).decode()
+                + f'{self._key}{file_path[file_path.rfind("."):]}{self._key}'
+            )
 
     def _remove_ext_from_string(self, file_as_str_with_extension: str) -> str:
-        '''
+        """
         Removes the extension from the string.
 
         Args:
             file_as_str_with_extension: File as string with the extension appended
         Returns:
             cleaned_string: File as string without the extension
-        '''
-        cleaned_string = file_as_str_with_extension[:file_as_str_with_extension.find(self._key)]
-        self.extension = file_as_str_with_extension[file_as_str_with_extension.find(self._key)+len(self._key):file_as_str_with_extension.rfind(self._key)]
+        """
+        cleaned_string = file_as_str_with_extension[
+            : file_as_str_with_extension.find(self._key)
+        ]
+        self.extension = file_as_str_with_extension[
+            file_as_str_with_extension.find(self._key)
+            + len(self._key) : file_as_str_with_extension.rfind(self._key)
+        ]
         return cleaned_string
 
     def file_get_bytes(self, file_as_str_with_extension: str) -> bytes:
-        '''
-        Use this method to manipulate the sent file. 
+        """
+        Use this method to manipulate the sent file.
         The output of this function is the final form of the file and can be directly read and manipulated or written into another file.
 
         Args:
             file_as_str_with_extension: File in string format as sent via the API. Includes the extension of the source file.
         Return:
-            file_as_bytes: Bytes representation of the file. 
-        '''
+            file_as_bytes: Bytes representation of the file.
+        """
         cleaned_str = self._remove_ext_from_string(file_as_str_with_extension)
         file_as_bytes = base64.decodebytes(cleaned_str.encode())
         return file_as_bytes
-    
+
     def to_api(self) -> str:
-        '''
+        """
         Provides a unified method to send io objects across the API. This should be the last stage before passing the desired object to api.run() function.
-        '''
+        """
         return self._file_to_str_with_extension(self.path)


### PR DESCRIPTION
This PR adds a file handler designed for runtime. Used in pipelines where the input requires a local file not found on the server. Example: Whisper model by OpenAI expects the audio file that needs to be processed, this PR adds helper functions to serialise the audio file. 