### PR TITLE
Exception on upload run

### DIFF
--- a/pipeline/api/cloud.py
+++ b/pipeline/api/cloud.py
@@ -394,6 +394,8 @@ class PipelineCloud:
             Returns:
                     pipeline (PipelineGet): Object representing uploaded pipeline.
         """
+        if new_pipeline_graph._has_run_startup:
+            raise Exception("Cannot upload a pipeline that has already been run.")
 
         new_name = new_pipeline_graph.name
         print("Uploading functions")


### PR DESCRIPTION
Pipelines that have been run locally cannot be correctly uploaded due to serialisation issues. This PR raises an exception when a user tries to upload a pipeline that has already been run locally.