### PR TITLE
Add more detailed error info in RunGet

### DIFF
--- a/pipeline/schemas/run.py
+++ b/pipeline/schemas/run.py
@@ -29,10 +29,19 @@ class RunState(Enum):
     FAILED = "failed"
 
 
-class RunError(Enum):
+class RunErrorType(Enum):
+    """The type of error that occurred (if any)"""
+
     MAX_RETRIES = "max_retries"
     PIPELINE_FAULT = "pipeline_fault"
     UNSATISFIABLE = "unsatisfiable"
+
+
+class RunErrorInfo(BaseModel):
+    """More info about the error if it was a pipeline_fault"""
+
+    exception: str
+    traceback: str
 
 
 class RunCreate(BaseModel):
@@ -86,7 +95,8 @@ class RunGet(BaseModel):
     result: Optional[FileGet]
     #: JSON-serialised runnable return value, if available
     result_preview: Optional[Union[list, dict]]
-    error: Optional[RunError]
+    error: Optional[RunErrorType]
+    error_info: Optional[RunErrorInfo]
     compute_requirements: Optional[ComputeRequirements] = None
 
     class Config:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pipeline-ai"
-version = "0.0.47"
+version = "0.0.48"
 description = "Pipelines for machine learning workloads."
 authors = [
   "Paul Hetherington <ph@mystic.ai>",


### PR DESCRIPTION
Extra error info added so that exceptions and tracebacks can be reported to the client. Changes to the schemas have been made in a backwards-compatible way.