### PR TITLE
Remove harmful replace call

### DIFF
--- a/pipeline/util/__init__.py
+++ b/pipeline/util/__init__.py
@@ -17,7 +17,7 @@ def python_object_to_hex(obj: Any) -> str:
 
 
 def hex_to_python_object(hex: str) -> Any:
-    h = bytes.fromhex(hex).replace(b"\r\n", b"\n")
+    h = bytes.fromhex(hex)
     return loads(h)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pipeline-ai"
-version = "0.0.49"
+version = "0.0.50"
 description = "Pipelines for machine learning workloads."
 authors = [
   "Paul Hetherington <ph@mystic.ai>",


### PR DESCRIPTION
This blindly modifies the pickle payload, potentially invalidating it.