### PR TITLE
Improve progress feedback for pipeline file uploads

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pipeline-ai"
-version = "0.1.1"
+version = "0.1.2"
 
 description = "Pipelines for machine learning workloads."
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ authors = [
   "Alex Pearwin <alex@mystic.ai>",
   "Maximiliano Schulkin <max@mystic.ai>",
   "Neil Wang <neil@mystic.ai>",
+  "Ross Gray <ross@mystic.ai>",
 ]
 packages = [{ include = "pipeline" }]
 readme = "README.md"


### PR DESCRIPTION
These changes wrap the data passed to `requests.post` in a `BytesIO` object, which is in turn wrapped in a `tqdm`'s `CallbackIOWrapper`. This allows `requests` to read in the data incrementally, which in turn calls the `tqdm` callback to update the progress bar.

Inspiration for this was taken from this [gist](https://gist.github.com/tyhoff/b757e6af83c1fd2b7b83057adf02c139)