### PR TITLE
add warning on pipeline upload from non-3.9 env

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@
 
 - [About](#about)
 - [Usage](#usage)
-  * [Huggingface Transformers](#huggingface-transformers)
+  - [Huggingface Transformers](#huggingface-transformers)
 - [Installation instructions](#installation-instructions)
-  * [Linux, Mac (intel)](#linux--mac--intel-)
-  * [Mac (arm/M1)](#mac--arm-m1-)
+  - [Linux, Mac (intel)](#linux--mac--intel-)
+  - [Mac (arm/M1)](#mac--arm-m1-)
 - [Development](#development)
 - [License](#license)
 
@@ -20,6 +20,8 @@ Pipeline is a python library that provides a simple way to construct computation
 The syntax used for defining AI/ML pipelines shares some similarities in syntax to sessions in [Tensorflow v1](https://www.tensorflow.org/api_docs/python/tf/compat/v1/InteractiveSession), and Flows found in [Prefect](https://github.com/PrefectHQ/prefect). In future releases we will be moving away from this syntax to a C based graph compiler which interprets python directly (and other languages) allowing users of the API to compose graphs in a more native way to the chosen language.
 
 # Usage
+
+> :warning: **Uploading pipelines to Pipeline Cloud works best in Python 3.9.** We strongly recommend you use Python 3.9 when uploading pipelines because the `pipeline-ai` library is still in beta and is known to cause opaque errors when pipelines are serialised from a non-3.9 environment.
 
 ## Huggingface Transformers
 
@@ -93,6 +95,7 @@ conda install -c huggingface transformers -y
 ```
 python -m pip install -U pipeline-ai
 ```
+
 # Development
 
 This project is made with poetry, [so firstly setup poetry on your machine](https://python-poetry.org/docs/#installation).
@@ -103,7 +106,6 @@ Once that is done, please run
 
 With this you should be good to go. This sets up dependencies, pre-commit hooks and
 pre-push hooks.
-
 
 You can manually run pre commit hooks with
 

--- a/pipeline/api/cloud.py
+++ b/pipeline/api/cloud.py
@@ -442,8 +442,7 @@ class PipelineCloud:
                 " upload_pipeline function has only been tested in Python 3.9. "
                 "We strongly recommend you use Python 3.9 as pipelines uploaded"
                 " in other Python versions are known to be broken. We are working"
-                "on adding support for 3.10 and 3.8; join us on Discord"
-                " https://discord.com/invite/7REbAX5v3N if you'd like to help us!"
+                "on adding support for 3.10 and 3.8!"
             )
 
         new_name = new_pipeline_graph.name

--- a/pipeline/api/cloud.py
+++ b/pipeline/api/cloud.py
@@ -435,9 +435,8 @@ class PipelineCloud:
         """
         if new_pipeline_graph._has_run_startup:
             raise Exception("Cannot upload a pipeline that has already been run.")
-        if sys.version_info.major != 3 or (
-            sys.version_info.major == 3 and sys.version_info.minor != 9
-        ):
+        # Pipeline Cloud currently supports Python 3.9.x only
+        if (sys.version_info.major, sys.version_info.minor) != (3, 9):
             print(
                 "WARNING: pipeline-ai is still in development and the"
                 " upload_pipeline function has only been tested in Python 3.9. "

--- a/pipeline/api/cloud.py
+++ b/pipeline/api/cloud.py
@@ -7,6 +7,7 @@ import os
 import urllib.parse
 from http import HTTPStatus
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Type, Union
+import sys
 
 import httpx
 import requests
@@ -434,6 +435,12 @@ class PipelineCloud:
         """
         if new_pipeline_graph._has_run_startup:
             raise Exception("Cannot upload a pipeline that has already been run.")
+        if sys.version_info.major != 3 or (
+            sys.version_info.major == 3 and sys.version_info.minor != 9
+        ):
+            print(
+                "WARNING: pipeline-ai is still in development and the upload_pipeline function has only been tested in Python 3.9. We strongly recommend you use Python 3.9 as pipelines uploaded in other Python versions are known to be broken. We are working on adding support for 3.10 and 3.8; join us on Discord https://discord.com/invite/7REbAX5v3N if you'd like to help us!"
+            )
 
         new_name = new_pipeline_graph.name
         if self.verbose:

--- a/pipeline/api/cloud.py
+++ b/pipeline/api/cloud.py
@@ -4,10 +4,10 @@ import hashlib
 import io
 import json
 import os
+import sys
 import urllib.parse
 from http import HTTPStatus
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Type, Union
-import sys
 
 import httpx
 import requests

--- a/pipeline/api/cloud.py
+++ b/pipeline/api/cloud.py
@@ -439,7 +439,12 @@ class PipelineCloud:
             sys.version_info.major == 3 and sys.version_info.minor != 9
         ):
             print(
-                "WARNING: pipeline-ai is still in development and the upload_pipeline function has only been tested in Python 3.9. We strongly recommend you use Python 3.9 as pipelines uploaded in other Python versions are known to be broken. We are working on adding support for 3.10 and 3.8; join us on Discord https://discord.com/invite/7REbAX5v3N if you'd like to help us!"
+                "WARNING: pipeline-ai is still in development and the"
+                " upload_pipeline function has only been tested in Python 3.9. "
+                "We strongly recommend you use Python 3.9 as pipelines uploaded"
+                " in other Python versions are known to be broken. We are working"
+                "on adding support for 3.10 and 3.8; join us on Discord"
+                " https://discord.com/invite/7REbAX5v3N if you'd like to help us!"
             )
 
         new_name = new_pipeline_graph.name


### PR DESCRIPTION
Uploading pipelines in 3.10 and occasionally in 3.8 is buggy and often mysteriously so. This change at least advises users to use Python 3.9, until upload support for 3.10 and onwards is in place.