### PR TITLE
Deployment create by pipeline schema

### DIFF
--- a/pipeline/schemas/deployment.py
+++ b/pipeline/schemas/deployment.py
@@ -6,13 +6,11 @@ from pipeline.schemas.project import ProjectGet
 
 
 class DeploymentCreate(BaseModel):
-    project_id: str
-    pipeline_id: str
+    """Schema for creating a pipeline deployment"""
 
-
-class DefaultProjectDeploymentCreate(BaseModel):
-    """Schema for creating a deployment on a users' default project"""
     pipeline_id: str
+    # If not provided, deployment will be created with users' default project
+    project_id: Optional[str] = None
 
 
 class DeploymentGet(BaseModel):

--- a/pipeline/schemas/deployment.py
+++ b/pipeline/schemas/deployment.py
@@ -10,6 +10,11 @@ class DeploymentCreate(BaseModel):
     pipeline_id: str
 
 
+class DefaultProjectDeploymentCreate(BaseModel):
+    """Schema for creating a deployment on a users' default project"""
+    pipeline_id: str
+
+
 class DeploymentGet(BaseModel):
     id: str
     pipeline: PipelineGet

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pipeline-ai"
-version = "0.1.4"
+version = "0.1.5"
 
 description = "Pipelines for machine learning workloads."
 authors = [


### PR DESCRIPTION
Allow optional `project_id` in `DeploymentCreate` schema. When `project_id=None`, deployment will be created using users' default project.