### PR TITLE
Paul/cli login fix

### DIFF
--- a/pipeline/configuration.py
+++ b/pipeline/configuration.py
@@ -32,6 +32,7 @@ remote_auth: TypedDict("remote_auth", {"url": str}) = dict()
 
 
 def _load_auth():
+    global remote_auth
     if PIPELINE_CACHE_AUTH.exists():
         remote_auth = json.loads(PIPELINE_CACHE_AUTH.read_text())
         remote_auth = {
@@ -42,7 +43,8 @@ def _load_auth():
 
 def _save_auth():
     PIPELINE_CACHE.mkdir(exist_ok=True)
-    with open(os.path.join(PIPELINE_CACHE, "auth.json"), "w") as auth_file:
+
+    with open(PIPELINE_CACHE_AUTH, "w") as auth_file:
 
         _b64_remote_auth = {
             auth[0]: base64.b64encode(auth[1].encode()).decode()
@@ -52,5 +54,4 @@ def _save_auth():
         auth_file.write(json.dumps(_b64_remote_auth))
 
 
-if PIPELINE_CACHE_AUTH.exists():
-    _load_auth()
+_load_auth()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pipeline-ai"
-version = "0.2.3"
+version = "0.2.4"
 
 
 description = "Pipelines for machine learning workloads."


### PR DESCRIPTION
# Pull request outline
The `remote_auth` variable was only being set locally from the `_load_auth` function in the configuration file. This PR makes it globally set.

## Checklist:

- [x] Version bumped

~~- [ ] Docs updated~~
~~- [ ] Tests written~~
~~- [ ] Check for breaking changes in Resource~~

Added:
_none_

Changed:
- Change the `remote_auth` to global inside of the `_load_auth` configuration file.

Removed:
_none_

## Related issues:
- #174 

___

- _You can add a reference to an issue using hash followed by the issue number_
- _If a checklist item is to be ignored it must be struck through_
