### PR TITLE
Improve error handling when server error returns non-JSON response

### DIFF
--- a/pipeline/api/cloud.py
+++ b/pipeline/api/cloud.py
@@ -147,7 +147,11 @@ class PipelineCloud:
             isinstance(response, httpx.Response)
             and not response.status_code == httpx.codes.OK
         ):
-            content = response.json()
+            try:
+                content = response.json()
+            except json.JSONDecodeError:
+                response.raise_for_status()
+
             # Every exception has content of {detail, status_code[, headers]}
             # TODO Some exceptions in Top send detail as a string and not a dict.
             # These exceptions are now handled like normal HTTP exceptions.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,6 @@
 [tool.poetry]
 name = "pipeline-ai"
-version = "0.2.5"
-
-
+version = "0.2.6"
 
 description = "Pipelines for machine learning workloads."
 authors = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -149,6 +149,12 @@ def api_response(
                 ),
             ],
         )
+        rsps.add(
+            responses.POST,
+            url + "/error/500",
+            status=500,
+            match=[matchers.header_matcher({"Authorization": "Bearer " + token})],
+        )
         yield rsps
 
 

--- a/tests/test_pipeline_cloud.py
+++ b/tests/test_pipeline_cloud.py
@@ -1,4 +1,5 @@
 import pytest
+import requests
 
 from pipeline import PipelineCloud
 from pipeline.exceptions.InvalidSchema import InvalidSchema
@@ -81,3 +82,10 @@ def test_cloud_upload_pipeline_file(
         pipeline_file_var_get.file.dict()
         == finalise_direct_pipeline_file_upload_get_json["hex_file"]
     )
+
+
+@pytest.mark.usefixtures("api_response")
+def test_cloud_get_raise_for_status_when_non_json_error(url, token):
+    api = PipelineCloud(url=url, token=token)
+    with pytest.raises(requests.HTTPError, match="500 Server Error"):
+        api._post("/error/500", json_data={})


### PR DESCRIPTION
# Pull request outline

Currently when there is an error response from the API without a JSON body, the client receives a JSON decoding error rather than the actual error from the server.

For example, if the server returns a 503 error (which does not have a JSON body) the client will not see this, they will instead see something like `requests.exceptions.JSONDecodeError: Expecting value: line 1 column 1 (char 0)`


## Checklist:
~- [ ] Docs updated~
- [x] Tests written

~- [ ] Check for breaking changes in Resource~
- [x] Version bumped

Changed:
- Improved error handling when server error returns non-JSON response 

## Related issues:
_none_
