### PR TITLE
Add file format schemas

### DIFF
--- a/pipeline/schemas/file.py
+++ b/pipeline/schemas/file.py
@@ -1,10 +1,20 @@
+import enum
 from typing import Optional
 
 from .base import BaseModel
 
 
+class FileFormat(str, enum.Enum):
+    """Represents the different formats files can be uploaded in"""
+
+    hex = "hex"
+    binary = "binary"
+
+
 class FileBase(BaseModel):
     name: str
+    # hex is the default purely for backwards-compatability
+    file_format: FileFormat = FileFormat.hex
 
 
 class FileGet(FileBase):

--- a/pipeline/schemas/pipeline_file.py
+++ b/pipeline/schemas/pipeline_file.py
@@ -1,11 +1,13 @@
-from typing import List
+from typing import List, Optional
 
 from .base import BaseModel
-from .file import FileGet
+from .file import FileFormat, FileGet
 
 
 class PipelineFileDirectUploadInitCreate(BaseModel):
     file_size: int
+    # hex is the default purely for backwards-compatability
+    file_format: FileFormat = FileFormat.hex
 
 
 class PipelineFileDirectUploadInitGet(BaseModel):
@@ -42,4 +44,7 @@ class PipelineFileDirectUploadFinaliseCreate(BaseModel):
 class PipelineFileGet(BaseModel):
     id: str
     name: str
-    hex_file: FileGet
+    # This is a legacy field that is replaced by 'file'.
+    # Can be deprecated once no clients are using it.
+    hex_file: Optional[FileGet]
+    file: Optional[FileGet]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,6 @@
 [tool.poetry]
 name = "pipeline-ai"
-version = "0.2.8b"
-
-
+version = "0.2.9"
 description = "Pipelines for machine learning workloads."
 authors = [
   "Paul Hetherington <ph@mystic.ai>",


### PR DESCRIPTION
# Pull request outline

Updating schemas in order to support pipeline file uploads in formats other than hex. 

## Checklist:
~- [ ] Docs updated~
~- [ ] Tests written~
~- [ ] Check for breaking changes in Resource~
- [x] Version bumped

Added:
- `FileFormat` schema

Changed:
- File-related schemas to support passing in the file format

## Related issues:
_none_
