### PR TITLE
Upload PipelineFiles as binary rather than hex

### DIFF
--- a/pipeline/api/cloud.py
+++ b/pipeline/api/cloud.py
@@ -275,7 +275,7 @@ class PipelineCloud:
                 desc=f"{PIPELINE_FILE_STR} Uploading {pipeline_file.path}",
                 unit="B",
                 unit_scale=True,
-                total=file_size * 2,  # since we hex encode the data
+                total=file_size,
                 unit_divisor=1024,
             )
         with open(pipeline_file.path, "rb") as f:

--- a/pipeline/api/cloud.py
+++ b/pipeline/api/cloud.py
@@ -266,10 +266,7 @@ class PipelineCloud:
         )
 
         parts = []
-        # Create file hash with arbitrary initial data.
-        # Since we were previously hex-encoding the file data we want to prevent 2
-        # versions of the same file (one hex-encoded and one not) having the same hash.
-        file_hash = hashlib.md5("pipeline file".encode())
+        file_hash = hashlib.sha256()
         if self.verbose:
             progress = tqdm(
                 desc=f"{PIPELINE_FILE_STR} Uploading {pipeline_file.path}",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pipeline-ai"
-version = "0.2.10"
+version = "0.2.11"
 description = "Pipelines for machine learning workloads."
 authors = [
   "Paul Hetherington <ph@mystic.ai>",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -359,7 +359,7 @@ def finalise_direct_pipeline_file_upload_get_json():
     return PipelineFileGet(
         id="pipeline_file_id",
         name="pipeline_file_id",
-        hex_file=FileGet(
+        file=FileGet(
             name="pipeline_file_id",
             id="dummy_file_id",
             path="pipeline_file_id",

--- a/tests/test_pipeline_cloud.py
+++ b/tests/test_pipeline_cloud.py
@@ -80,7 +80,7 @@ def test_cloud_upload_pipeline_file(
     assert pipeline_file_var_get.path == str(file)
     assert (
         pipeline_file_var_get.file.dict()
-        == finalise_direct_pipeline_file_upload_get_json["hex_file"]
+        == finalise_direct_pipeline_file_upload_get_json["file"]
     )
 
 


### PR DESCRIPTION
# Pull request outline

Currently we hex-encode all data before uploading it to the server. This PR switches to using binary as the default file format for `PipelineFile`s. A subsequent PR(s) will be created to do the same for other types of data.

## Checklist:
~- [ ] Docs updated~
~- [ ] Tests written~
- [x] Check for breaking changes in Resource
- [x] Version bumped

Changed:
- Changed default encoding for `PipelineFile` uploads to be binary rather than hex

## Related issues:
_none_