### PR TITLE
Use multipart upload API for file-backed resources

### DIFF
--- a/pipeline/objects/model.py
+++ b/pipeline/objects/model.py
@@ -4,7 +4,7 @@ from hashlib import sha256
 from typing import Any
 
 from pipeline.schemas.model import ModelGet
-from pipeline.util import generate_id, hex_to_python_object
+from pipeline.util import generate_id, load_object
 
 
 class Model:
@@ -33,7 +33,7 @@ class Model:
 
     @classmethod
     def from_schema(cls, schema: ModelGet):
-        pickled_data = hex_to_python_object(schema.hex_file.data)
+        pickled_data = load_object(schema.hex_file.data)
         if isinstance(pickled_data, Model):
             pickled_data.local_id = schema.id
             return pickled_data

--- a/pipeline/objects/variable.py
+++ b/pipeline/objects/variable.py
@@ -1,7 +1,7 @@
 from typing import Any
 
 from pipeline.schemas.pipeline import PipelineVariableGet
-from pipeline.util import generate_id, hex_to_python_object
+from pipeline.util import generate_id, load_object
 
 
 class Variable:
@@ -40,7 +40,7 @@ class Variable:
             return PipelineFile.from_schema(schema)
         else:
             return cls(
-                hex_to_python_object(schema.type_file.data),
+                load_object(schema.type_file.data),
                 is_input=schema.is_input,
                 is_output=schema.is_output,
                 name=schema.name,

--- a/pipeline/schemas/file.py
+++ b/pipeline/schemas/file.py
@@ -1,5 +1,7 @@
 import enum
-from typing import Optional
+from typing import Optional, Union
+
+from pydantic import StrictBytes, StrictStr
 
 from .base import BaseModel
 
@@ -20,8 +22,8 @@ class FileBase(BaseModel):
 class FileGet(FileBase):
     id: str
     path: str
-    #: The data as hex-encoded bytes, if the data size is less than 20 kB
-    data: Optional[str]
+    #: When str, the data are hex-encoded bytes, else plain bytes
+    data: Optional[Union[StrictBytes, StrictStr]]
     #: The data size in bytes
     file_size: int
 

--- a/pipeline/schemas/pipeline.py
+++ b/pipeline/schemas/pipeline.py
@@ -27,6 +27,39 @@ class PipelineFileVariableGet(BaseModel):
     file: FileGet
 
 
+class PipelineVariableCreate(BaseModel):
+    local_id: str
+    name: Optional[str]
+
+    type_file: Optional[FileGet] = Field(
+        default=None,
+        deprecated=True,
+        description="Use multipart Pipeline creation instead.",
+    )
+    type_file_id: Optional[str] = Field(
+        default=None,
+        deprecated=True,
+        description="Use multipart Pipeline creation instead.",
+    )
+
+    is_input: bool
+    is_output: bool
+
+    pipeline_file_variable: Optional[PipelineFileVariableGet]
+
+    @root_validator
+    def file_or_id_validation(cls, values):
+        # If either deprecated field is set, verify that only one of them is set.
+        type_file_defined = values.get("type_file") is not None
+        type_file_id_defined = values.get("type_file_id") is not None
+        deprecated_fields = type_file_defined or type_file_id_defined
+        if deprecated_fields and type_file_defined == type_file_id_defined:
+            raise ValueError(
+                "Inline file must be set using `type_file` OR `type_file_id`."
+            )
+        return values
+
+
 class PipelineVariableGet(BaseModel):
     local_id: str
     name: Optional[str]
@@ -88,7 +121,7 @@ class PipelineGetDetailed(PipelineGet):
 
 class PipelineCreate(BaseModel):
     name: str
-    variables: List[PipelineVariableGet]
+    variables: List[PipelineVariableCreate]
     functions: List[FunctionGet]
     models: List[ModelGet]
     graph_nodes: List[PipelineGraphNode]

--- a/pipeline/util/__init__.py
+++ b/pipeline/util/__init__.py
@@ -2,7 +2,7 @@ import importlib.metadata
 import io
 import random
 import string
-from typing import Any, Callable, Optional
+from typing import Any, Callable, Optional, Union
 
 from cloudpickle import dumps
 from dill import loads
@@ -26,6 +26,19 @@ def python_object_to_hex(obj: Any) -> str:
 def hex_to_python_object(hex: str) -> Any:
     h = bytes.fromhex(hex)
     return loads(h)
+
+
+def dump_object(obj: Any) -> bytes:
+    """Serialize `obj` as bytes."""
+    return dumps(obj)
+
+
+def load_object(pickled: Union[bytes, str]) -> Any:
+    """Deserialize an object from the payload."""
+    if isinstance(pickled, str):
+        return hex_to_python_object(pickled)
+    else:
+        return loads(pickled)
 
 
 def python_object_to_name(obj: Any) -> Optional[str]:

--- a/poetry.lock
+++ b/poetry.lock
@@ -270,11 +270,14 @@ setuptools = "*"
 
 [[package]]
 name = "packaging"
-version = "22.0"
+version = "21.3"
 description = "Core utilities for Python packages"
 category = "main"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyparsing = ">=2.0.2,<3.0.5 || >3.0.5"
 
 [[package]]
 name = "pathspec"
@@ -370,6 +373,17 @@ description = "🐫  Convert strings (and dictionary keys) between snake case, c
 category = "main"
 optional = false
 python-versions = "*"
+
+[[package]]
+name = "pyparsing"
+version = "3.0.9"
+description = "pyparsing module - Classes and methods to define and execute parsing grammars"
+category = "main"
+optional = false
+python-versions = ">=3.6.8"
+
+[package.extras]
+diagrams = ["railroad-diagrams", "jinja2"]
 
 [[package]]
 name = "pytest"
@@ -682,8 +696,8 @@ nodeenv = [
     {file = "nodeenv-1.7.0.tar.gz", hash = "sha256:e0e7f7dfb85fc5394c6fe1e8fa98131a2473e04311a45afb6508f7cf1836fa2b"},
 ]
 packaging = [
-    {file = "packaging-22.0-py3-none-any.whl", hash = "sha256:957e2148ba0e1a3b282772e791ef1d8083648bc131c8ab0c1feba110ce1146c3"},
-    {file = "packaging-22.0.tar.gz", hash = "sha256:2198ec20bd4c017b8f9717e00f0c8714076fc2fd93816750ab48e2c41de2cfd3"},
+    {file = "packaging-21.3-py3-none-any.whl", hash = "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"},
+    {file = "packaging-21.3.tar.gz", hash = "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb"},
 ]
 pathspec = [
     {file = "pathspec-0.10.3-py3-none-any.whl", hash = "sha256:3c95343af8b756205e2aba76e843ba9520a24dd84f68c22b9f93251507509dd6"},
@@ -754,6 +768,10 @@ pyflakes = [
 pyhumps = [
     {file = "pyhumps-3.8.0-py3-none-any.whl", hash = "sha256:060e1954d9069f428232a1adda165db0b9d8dfdce1d265d36df7fbff540acfd6"},
     {file = "pyhumps-3.8.0.tar.gz", hash = "sha256:498026258f7ee1a8e447c2e28526c0bea9407f9a59c03260aee4bd6c04d681a3"},
+]
+pyparsing = [
+    {file = "pyparsing-3.0.9-py3-none-any.whl", hash = "sha256:5026bae9a10eeaefb61dab2f09052b9f4307d44aee4eda64b309723d8d206bbc"},
+    {file = "pyparsing-3.0.9.tar.gz", hash = "sha256:2b020ecf7d21b687f219b71ecad3631f644a47f01403fa1d1036b0c6416d70fb"},
 ]
 pytest = [
     {file = "pytest-6.2.5-py3-none-any.whl", hash = "sha256:7310f8d27bc79ced999e760ca304d69f6ba6c6649c0b60fb0e04a4a77cacc134"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pipeline-ai"
-version = "0.4.0"
+version = "0.4.1"
 
 description = "Pipelines for machine learning workloads."
 authors = [

--- a/tests/test_pipeline_cloud.py
+++ b/tests/test_pipeline_cloud.py
@@ -20,13 +20,6 @@ def test_cloud_init_failure(url, top_api_server_bad_token, bad_token):
 
 
 @pytest.mark.usefixtures("top_api_server")
-def test_cloud_upload_file(url, token, file_get, tmp_file):
-    api = PipelineCloud(url=url, token=token)
-    f = api.upload_file(tmp_file)
-    assert f == file_get
-
-
-@pytest.mark.usefixtures("top_api_server")
 def test_cloud_upload_function_fail(url, token):
     api = PipelineCloud(url=url, token=token)
     with pytest.raises(InvalidSchema):


### PR DESCRIPTION
Switch to the new multipart upload strategy for creating API resources backed by files. This affects the creation of Data, Function, Model, and Pipeline.

The previous strategy, soon to be deprecated in the API, was to upload each backing files to the `POST /v2/files/` endpoint and then use the resulting File IDs in a separate request to create the resource, e.g. a Function.

The new strategy submits a single [multipart request](https://www.w3.org/Protocols/rfc1341/7_2_Multipart.html) which consists of one part for the usual JSON payload, minus any File IDs, and one part for each backing file.

The new strategy has a few of advantages:

1. The client only makes a single request, reducing total execution time.
2. Backing files are now uploaded in their binary form, rather than being hex-encoded, reducing execution time by removing the hex-encoded step and reducing bandwidth usage and the binary form is a factor 2 smaller.
3. Resource creation is now atomic with the creation of backing files, elimanating the possibility of creating 'dangling' Files (Files not referenced by a resource).

## Checklist:
- [x] ~~Docs updated~~ not required as no user-facing changes.
- [x] Tests written
- [x] Check for breaking changes in Resource
- [x] Version bumped to v0.3.5.

Added:
- Helpers for loading and dumping which are compatible between both hex-encoded and binary payloads.

Changed:
- Use multipart requests for creating Data, Function, Model, and Pipeline resources.
- `file` and `file_id` fields of `*Create` schemas are now marked as deprecated. API clients should instead provide files as part of a single multipart request rather than including a `FileGet` or File ID.

Removed:
- Unused `FunctionIOCreate` schema.

## Related issues:

Towards BE-207.