### PR TITLE
Relax packaging version

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -535,7 +535,7 @@ docker = ["PyYAML"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "52ac0e60025d4dfc837740bcb37a74fd0265d5586ba9e1bd753a14f6b06077c9"
+content-hash = "c09eb4f1a4868b44f3979e7f516bc856aa322be8d59a590b1b85b1ba987d3639"
 
 [metadata.files]
 anyio = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pipeline-ai"
-version = "0.3.0"
+version = "0.3.1"
 
 description = "Pipelines for machine learning workloads."
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ cloudpickle = "^2.2.0"
 dill = "^0.3.6"
 httpx = "^0.23.1"
 tabulate = "^0.9.0"
-packaging = "^22.0"
+packaging = ">=21.0"
 
 [tool.poetry.dev-dependencies]
 pydantic = "^1.8.2"


### PR DESCRIPTION
AFAIK we don't strictly need `packaging>=22.0` and so I relaxed the constraint a little to `>=21.0`. This allows broader compatibility with other packages, which may require less recent versions of `packaging`.

## Checklist:
- [ ] ~Docs updated~
- [ ] ~Tests written~
- [x] Check for breaking changes in Resource
- [x] Version bumped

Changed:
- Relaxed `packaging` version requirement.
- Bumped version to 0.3.1.