### PR TITLE
Pipeline tag regex update

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pipeline-ai"
-version = "0.3.5"
+version = "0.3.6"
 
 description = "Pipelines for machine learning workloads."
 authors = [


### PR DESCRIPTION
Changed:
- Fix regex mismatch for pipeline tag names between pipeline `CLI` and `pipeline-top`
