### PR TITLE
Set pipeline-ai version in user agent

### DIFF
--- a/pipeline/api/cloud.py
+++ b/pipeline/api/cloud.py
@@ -5,7 +5,6 @@ import io
 import json
 import os
 import sys
-import urllib.parse
 import uuid
 from http import HTTPStatus
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Type, Union
@@ -69,46 +68,60 @@ class PipelineCloud:
         timeout: float = 60.0,
         verbose: bool = True,
     ):
-        self.url = url or os.getenv("PIPELINE_API_URL", configuration.DEFAULT_REMOTE)
+        if url is None:
+            url = os.environ.get(
+                "PIPELINE_API_URL",
+                configuration.DEFAULT_REMOTE,
+            )
+        if token is None:
+            token = os.environ.get(
+                "PIPELINE_API_TOKEN",
+                configuration.remote_auth.get(url),
+            )
+        self._initialise_client(url, token, timeout)
 
-        self.token = (
-            token
-            or os.getenv("PIPELINE_API_TOKEN")
-            or configuration.remote_auth.get(self.url)
-        )
-
-        self.timeout = timeout
         self.verbose = verbose
         self.__valid_token__ = False
         if self.token is not None:
             self.authenticate()
 
-    def authenticate(self, token: str = None) -> None:
-        """
-        Authenticate with the pipeline.ai API
-            Parameters:
-                token (str): API user token for authentication.
-                    Pass it as an arg or set it as an ENV var.
-            Returns:
-                None
-        """
+    def _initialise_client(self, url: str, token: str, timeout: float) -> None:
+        self._url = url
+        self._token = token
+        self._timeout = timeout
+        self.client = httpx.Client(
+            base_url=self.url,
+            headers=dict(authorization=f"Bearer {self.token}"),
+            timeout=self._timeout,
+        )
+
+    @property
+    def token(self):
+        return self._token
+
+    @property
+    def url(self):
+        return self._url
+
+    def authenticate(self) -> None:
+        """Authenticate with the pipeline.ai API."""
         if self.verbose:
             print("Authenticating")
 
-        _token = token or self.token
-        if _token is None:
+        if self.token is None:
             raise MissingActiveToken(
-                token="", message="Please pass a valid token or set it as an ENV var"
+                token="",
+                message="Please pass a valid token or set it as an ENV var",
             )
 
-        valid_token = self._validate_token(_token, self.url)
+        response = self.client.get("/v2/users/me")
+        if response.status_code in {HTTPStatus.UNAUTHORIZED, HTTPStatus.FORBIDDEN}:
+            raise MissingActiveToken(token=self.token)
+        else:
+            self._get_raise_for_status(response)
 
-        if not valid_token:
-            raise MissingActiveToken(token=_token)
-        elif self.verbose:
+        if self.verbose:
             print("Succesfully authenticated with the Pipeline API (%s)" % self.url)
-
-        self.token = _token
         self.__valid_token__ = True
 
     def raise_for_invalid_token(self):
@@ -121,22 +134,6 @@ class PipelineCloud:
                     "or pass a valid token as a parameter authenticate(token)"
                 ),
             )
-
-    @staticmethod
-    def _validate_token(token: str, base_url: str) -> bool:
-        url = urllib.parse.urljoin(base_url, "/v2/users/me")
-
-        headers = {"Authorization": f"Bearer {token}"}
-        response = httpx.get(url, headers=headers)
-        if response.status_code == HTTPStatus.OK:
-            return True
-        elif (
-            response.status_code == HTTPStatus.UNAUTHORIZED
-            or response.status_code == HTTPStatus.FORBIDDEN
-        ):
-            return False
-        else:
-            response.raise_for_status()
 
     @staticmethod
     def _get_raise_for_status(response: httpx.Response) -> None:
@@ -224,10 +221,9 @@ class PipelineCloud:
         )
         part_upload_get = PipelineFileDirectUploadPartGet.parse_obj(response)
         # upload file chunk
-        response = httpx.put(
+        response = self.client.put(
             part_upload_get.upload_url,
             content=data,
-            timeout=self.timeout,
         )
 
         etag = response.headers["ETag"]
@@ -308,64 +304,34 @@ class PipelineCloud:
         )
 
     def _get(self, endpoint: str, params: Dict[str, Any] = None):
-        headers = {
-            "Authorization": "Bearer %s" % self.token,
-        }
-
-        url = urllib.parse.urljoin(self.url, endpoint)
-        response = httpx.get(url, headers=headers, params=params, timeout=self.timeout)
+        self.raise_for_invalid_token()
+        response = self.client.get(endpoint, params=params)
         response.raise_for_status()
         return response.json()
 
     def _post(self, endpoint: str, json_data: dict) -> dict:
         self.raise_for_invalid_token()
-        headers = {
-            "Authorization": "Bearer %s" % self.token,
-            "Content-type": "application/json",
-        }
-
-        url = urllib.parse.urljoin(self.url, endpoint)
-        response = httpx.post(
-            url, headers=headers, json=json_data, timeout=self.timeout
-        )
-
+        response = self.client.post(endpoint, json=json_data)
         if response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY:
             schema = json_data
             raise InvalidSchema(schema=schema)
         else:
             self._get_raise_for_status(response)
-
         return response.json()
 
     def _patch(self, endpoint: str, json_data: dict) -> dict:
         self.raise_for_invalid_token()
-        headers = {
-            "Authorization": "Bearer %s" % self.token,
-            "Content-type": "application/json",
-        }
-
-        url = urllib.parse.urljoin(self.url, endpoint)
-        response = httpx.patch(
-            url, headers=headers, json=json_data, timeout=self.timeout
-        )
-
+        response = self.client.patch(endpoint, json=json_data)
         if response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY:
             schema = json_data
             raise InvalidSchema(schema=schema)
         else:
             self._get_raise_for_status(response)
-
         return response.json()
 
     def _delete(self, endpoint: str) -> None:
         self.raise_for_invalid_token()
-        headers = {
-            "Authorization": "Bearer %s" % self.token,
-            "Content-type": "application/json",
-        }
-
-        url = urllib.parse.urljoin(self.url, endpoint)
-        response = httpx.delete(url, headers=headers, timeout=self.timeout)
+        response = self.client.delete(endpoint)
         if response.status_code != HTTPStatus.NO_CONTENT:
             self._get_raise_for_status(response)
 
@@ -387,15 +353,9 @@ class PipelineCloud:
             # If verbose then wrap our file object in a tqdm callback
             file = CallbackIOWrapper(progress.update, file)
 
-        headers = {
-            "Authorization": "Bearer %s" % self.token,
-        }
-        url = urllib.parse.urljoin(self.url, endpoint)
-        response = httpx.post(
-            url,
-            headers=headers,
+        response = self.client.post(
+            endpoint,
             files={"file": (file.name, file, "application/octet-stream")},
-            timeout=self.timeout,
         )
         if self.verbose:
             progress.close()

--- a/pipeline/api/cloud.py
+++ b/pipeline/api/cloud.py
@@ -45,6 +45,7 @@ from pipeline.util import (
     CallbackBytesIO,
     generate_id,
     hex_to_python_object,
+    package_version,
     python_object_to_hex,
     python_object_to_name,
 )
@@ -91,7 +92,10 @@ class PipelineCloud:
         self._timeout = timeout
         self.client = httpx.Client(
             base_url=self.url,
-            headers=dict(authorization=f"Bearer {self.token}"),
+            headers={
+                "Authorization": f"Bearer {self.token}",
+                "User-Agent": f"pipeline-ai/{package_version()}",
+            },
             timeout=self._timeout,
         )
 

--- a/pipeline/console/remote.py
+++ b/pipeline/console/remote.py
@@ -1,6 +1,7 @@
 import argparse
 
 from pipeline import PipelineCloud, configuration
+from pipeline.exceptions.MissingActiveToken import MissingActiveToken
 from pipeline.util.logging import _print
 
 
@@ -24,13 +25,13 @@ def remote(args: argparse.Namespace) -> int:
         [print(_remote) for _remote in remotes]
         return 0
     elif sub_command == "login":
-        valid_token = PipelineCloud._validate_token(args.token, args.url)
+        try:
+            PipelineCloud(token=args.token, url=args.url, verbose=False)
+        except MissingActiveToken:
+            _print(f"Couldn't authenticate with {args.url}", level="ERROR")
+            return 1
 
-        if valid_token:
-            configuration.remote_auth[args.url] = args.token
-            configuration._save_auth()
-            _print(f"Successfully authenticated with {args.url}")
-            return 0
-
-        _print(f"Couldn't authenticate with {args.url}", level="ERROR")
-        return 1
+        configuration.remote_auth[args.url] = args.token
+        configuration._save_auth()
+        _print(f"Successfully authenticated with {args.url}")
+        return 0

--- a/pipeline/console/runs.py
+++ b/pipeline/console/runs.py
@@ -14,7 +14,6 @@ def runs(args: argparse.Namespace) -> int:
     sub_command = getattr(args, "sub-command", None)
 
     remote_service = PipelineCloud(verbose=False)
-    remote_service.authenticate()
 
     if sub_command in ["list", "ls"]:
         raw_result = remote_service.get_runs()

--- a/pipeline/console/tags.py
+++ b/pipeline/console/tags.py
@@ -35,7 +35,6 @@ def _get_tag(tag_name: str) -> PipelineTagGet:
         raise sys.exit(1)
 
     remote_service = PipelineCloud(verbose=False)
-    remote_service.authenticate()
     tag_information = PipelineTagGet.parse_obj(
         remote_service._get(f"/v2/pipeline-tags/by-name/{tag_name}")
     )
@@ -44,7 +43,6 @@ def _get_tag(tag_name: str) -> PipelineTagGet:
 
 def _update_or_create_tag(source: str, target: str, sub_command: str) -> PipelineTagGet:
     remote_service = PipelineCloud(verbose=False)
-    remote_service.authenticate()
     if not VALID_TAG_NAME.match(target):
         _print("Target tag must match pattern 'pipeline:tag'", level="ERROR")
         raise sys.exit(1)
@@ -81,7 +79,6 @@ def _list_tags(
     skip: int, limit: int, pipeline_id: str = None
 ) -> Paginated[PipelineTagGet]:
     remote_service = PipelineCloud(verbose=False)
-    remote_service.authenticate()
     response = remote_service._get(
         "/v2/pipeline-tags",
         params=dict(
@@ -99,7 +96,6 @@ def _list_tags(
 
 def _delete_tag(tag_name: str) -> None:
     remote_service = PipelineCloud(verbose=False)
-    remote_service.authenticate()
 
     tag_information = _get_tag(tag_name)
     remote_service._delete(f"/v2/pipeline-tags/{tag_information.id}")

--- a/pipeline/util/__init__.py
+++ b/pipeline/util/__init__.py
@@ -1,3 +1,4 @@
+import importlib.metadata
 import io
 import random
 import string
@@ -7,6 +8,11 @@ from cloudpickle import dumps
 from dill import loads
 
 from pipeline.schemas.file import FileCreate
+
+
+def package_version() -> str:
+    """Return the version of the installed `pipeline-ai` package."""
+    return importlib.metadata.version("pipeline-ai")
 
 
 def generate_id(length: int) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pipeline-ai"
-version = "0.3.7"
+version = "0.3.8"
 
 description = "Pipelines for machine learning workloads."
 authors = [

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,10 @@
+import re
+
+import pipeline.util
+
+
+def test_package_version():
+    version = pipeline.util.package_version()
+    # We don't care about the particular version, but
+    # it should match a particular form.
+    assert re.match(r"[0-9]{1,}\.[0-9]{1,}\.[0-9]{1,}", version)


### PR DESCRIPTION
Setting the [user agent header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent) to `pipeline-ai/{version}` will allow us to track usage per package version. This will be helpful in understanding when deprecated APIs can be removed.

## Checklist:
- [ ] ~~Docs updated~~
- [x] Tests written
- [ ] ~~Check for breaking changes in Resource~~
- [x] Version bumped

Added:
- N/A.

Changed:
- `PipelineCloud` now sends a `User-Agent` header of the form `pipeline-ai/{version}` when talking to the API.
- Refactored HTTP interactions in `PipelineCloud` to use a single HTTP client instance. Parameters common to all API requests, such as the `Authorization` header and the timeout, are now defined and used in a single place, making modifications easier.

Removed:
- N/A.

## Related issues:
_none_