### PR TITLE
Make `RunErrorInfo.traceback` optional

### DIFF
--- a/pipeline/schemas/run.py
+++ b/pipeline/schemas/run.py
@@ -41,7 +41,7 @@ class RunErrorInfo(BaseModel):
     """More info about the error if it was a pipeline_fault"""
 
     exception: str
-    traceback: str
+    traceback: Optional[str]
 
 
 class RunCreate(BaseModel):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pipeline-ai"
-version = "0.3.10"
+version = "0.3.11"
 
 description = "Pipelines for machine learning workloads."
 authors = [


### PR DESCRIPTION
# Pull request outline

We don't always have an error traceback and currently the API will only return the error info if the traceback exists.

## Checklist:
- [x] Version bumped

Changed:
- Made `RunErrorInfo.traceback` optional
