### PR TITLE
Send Environment ID during Pipeline creation.

### DIFF
--- a/pipeline/api/cloud.py
+++ b/pipeline/api/cloud.py
@@ -16,6 +16,7 @@ from tqdm import tqdm
 from tqdm.utils import CallbackIOWrapper
 
 from pipeline import configuration
+from pipeline.api.environments import PipelineCloudEnvironment, resolve_environment_id
 from pipeline.exceptions.InvalidSchema import InvalidSchema
 from pipeline.exceptions.MissingActiveToken import MissingActiveToken
 from pipeline.objects.variable import PipelineFile
@@ -55,6 +56,7 @@ if TYPE_CHECKING:
     from pipeline.objects import Function, Graph, Model
 
 FILE_CHUNK_SIZE = 200 * 1024 * 1024  # 200 MiB
+EnvironmentObjectOrID = Union[PipelineCloudEnvironment, str]
 
 
 class PipelineCloud:
@@ -421,6 +423,7 @@ class PipelineCloud:
         public: bool = False,
         description: str = "",
         tags: Set[str] = None,
+        environment: Optional[EnvironmentObjectOrID] = None,
     ) -> PipelineGet:
         """
         Upload a Pipeline to the Cloud.
@@ -432,6 +435,10 @@ class PipelineCloud:
                         Defaults to False.
                     description (str): Description of the Pipeline.
                     tags (Set[str]): Set of tags for the pipeline. Eg: {"BERT", "NLP"}
+                    environment (Optional[Union[PipelineCloudEnvironment, str]]):
+                        Identifier of the execution environment the pipeline
+                        should run within. If None (the default) a Mystic-
+                        provided default environment will be chosen.
 
             Returns:
                     pipeline (PipelineGet): Object representing uploaded pipeline.
@@ -524,6 +531,7 @@ class PipelineCloud:
                 tags=tags or set(),
                 compute_type=new_pipeline_graph.compute_type,
                 compute_requirements=compute_requirements,
+                environment_id=resolve_environment_id(environment),
             )
         except ValidationError as e:
             raise InvalidSchema(schema="Graph", message=str(e))

--- a/pipeline/api/environments.py
+++ b/pipeline/api/environments.py
@@ -1,0 +1,30 @@
+"""Pre-made public environments your pipelines can execute in."""
+from collections import namedtuple
+from typing import Optional, Union
+
+PipelineCloudEnvironment = namedtuple("PipelineCloudEnvironment", ["id", "name"])
+
+# TODO: add instructions for viewing this environment's contents.
+mystic_default_20230126 = PipelineCloudEnvironment(
+    id="environment_35a54969b7474150b87afdf155431884",
+    name="public/mystic-default-20230126",
+)
+
+DEFAULT_ENVIRONMENT = mystic_default_20230126
+
+
+def resolve_environment_id(
+    environment: Optional[Union[PipelineCloudEnvironment, str]] = None
+):
+    """Resolve the argument to a remote Environment ID.
+
+    Fall back to a 'default' environment hard-coded on the client.
+    """
+    if environment is None:
+        environment = DEFAULT_ENVIRONMENT
+    try:
+        environment_id = environment.id
+    except AttributeError:
+        # Assume `environment` is a str ID.
+        environment_id = environment
+    return environment_id

--- a/pipeline/schemas/pipeline.py
+++ b/pipeline/schemas/pipeline.py
@@ -98,6 +98,8 @@ class PipelineCreate(BaseModel):
     # By default a Pipeline will require GPU resources
     compute_type: ComputeType = ComputeType.gpu
     compute_requirements: Optional[ComputeRequirements]
+    # Execution environment, defines Python dependencies
+    environment_id: Optional[str]
 
     @validator("compute_requirements")
     def compute_type_is_gpu(cls, v, values):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pipeline-ai"
-version = "0.3.11"
+version = "0.3.12"
 
 description = "Pipelines for machine learning workloads."
 authors = [

--- a/tests/schemas/test_pipeline.py
+++ b/tests/schemas/test_pipeline.py
@@ -105,4 +105,5 @@ def test_pipeline_create_to_json():
         outputs=[],
         compute_type="gpu",
         compute_requirements=dict(min_gpu_vram_mb=4000),
+        environment_id=None,
     )

--- a/tests/test_api_environments.py
+++ b/tests/test_api_environments.py
@@ -1,0 +1,22 @@
+from pipeline.api.environments import DEFAULT_ENVIRONMENT, resolve_environment_id
+
+
+def test_environment_resolution_default():
+    """A `None` identifier should resolve to the default environment's ID."""
+    assert resolve_environment_id(environment=None) == DEFAULT_ENVIRONMENT.id
+
+
+def test_environment_resolution_string():
+    """A string indentifier should resolve to that string."""
+    value = "environment_abc123"
+    assert resolve_environment_id(environment=value) == value
+
+
+def test_environment_resolution_object():
+    """An object with an `id` property should resolve to the value of that property."""
+
+    class IDHolder:
+        id: str = "environment_cab321"
+
+    obj = IDHolder()
+    assert resolve_environment_id(environment=obj) == obj.id


### PR DESCRIPTION
The `PipelineCreate` schema now includes an _optional_ `environment_id` field, which defines the execution environment a pipeline will be run within on the compute resource. It must be optional to allow the API to support older clients.

The set of mystic-provided 'default' environments is hard-coded into the client as the new `pipeline.api.environments` module such that scripts can programatically reference a default if they wish.

Because environments are a Pipeline-Cloud-specific feature (local execution will use whatever environment the user has installed), I've gone for adding an `environment` argument to `PipelineCloud.upload_pipeline` rather than the `Pipeline` constructor. The `environment` argument is currently optional, and when it is `None` the client falls back to a fixed default environment. The name `environment` hints at the possibility of us supporting non-ID values in the future (e.g. names, or some other Python object representation).

## Checklist:
- [ ] ~~Docs updated~~ @paulcjh I've held off doing this as the specifics of what the current default environment contains are TBD, and can anyhow be updated at a later date. I don't think the broader docs of 'custom environment support' are within the scope of this PR.
- [x] Tests written
- [ ] ~~Check for breaking changes in Resource~~
- [x] Version bumped