### PR TITLE
add base environment schema + attach to pipeline detailed

### DIFF
--- a/pipeline/schemas/environment.py
+++ b/pipeline/schemas/environment.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from typing import List, Optional
 
 from pipeline.schemas.base import BaseModel
@@ -6,6 +7,12 @@ from pipeline.schemas.base import BaseModel
 class EnvironmentCreate(BaseModel):
     name: str
     python_requirements: List[str]
+
+
+class EnvironmentBase(BaseModel):
+    id: str
+    name: str
+    deleted_at: Optional[datetime]
 
 
 class EnvironmentGet(BaseModel):

--- a/pipeline/schemas/environment.py
+++ b/pipeline/schemas/environment.py
@@ -9,7 +9,7 @@ class EnvironmentCreate(BaseModel):
     python_requirements: List[str]
 
 
-class EnvironmentBase(BaseModel):
+class EnvironmentBrief(BaseModel):
     id: str
     name: str
     deleted_at: Optional[datetime]

--- a/pipeline/schemas/pipeline.py
+++ b/pipeline/schemas/pipeline.py
@@ -5,6 +5,7 @@ from pydantic import Field, root_validator, validator
 
 from pipeline.schemas.base import BaseModel
 from pipeline.schemas.compute_requirements import ComputeRequirements, ComputeType
+from pipeline.schemas.environment import EnvironmentBase
 from pipeline.schemas.file import FileGet
 from pipeline.schemas.function import FunctionGet
 from pipeline.schemas.model import ModelGet
@@ -80,6 +81,7 @@ class PipelineGetDetailed(PipelineGet):
     public: bool
     # Maps language, e.g. `curl` or `python`, to an example Run creation code snippet
     run_examples: Dict[str, str] = {}
+    environment: EnvironmentBase
 
 
 class PipelineCreate(BaseModel):

--- a/pipeline/schemas/pipeline.py
+++ b/pipeline/schemas/pipeline.py
@@ -5,7 +5,7 @@ from pydantic import Field, root_validator, validator
 
 from pipeline.schemas.base import BaseModel
 from pipeline.schemas.compute_requirements import ComputeRequirements, ComputeType
-from pipeline.schemas.environment import EnvironmentBase
+from pipeline.schemas.environment import EnvironmentBrief
 from pipeline.schemas.file import FileGet
 from pipeline.schemas.function import FunctionGet
 from pipeline.schemas.model import ModelGet
@@ -81,7 +81,7 @@ class PipelineGetDetailed(PipelineGet):
     public: bool
     # Maps language, e.g. `curl` or `python`, to an example Run creation code snippet
     run_examples: Dict[str, str] = {}
-    environment: EnvironmentBase
+    environment: EnvironmentBrief
 
 
 class PipelineCreate(BaseModel):


### PR DESCRIPTION
# Pull request outline

Added:
- A Base Environment Schema

Changed:
- Added Base environment to pipeline get detailed schema


## Related issues:
We want to attach environment information to pipeline responses. We could just attach the environment id. However, when a user deletes an environment, it would be useful for clients to be aware the environment has been deleted, avoiding them having to make an additional API and getting a `404 not found`. It is probably not a field we want to return in all EnvironmentGet responses, as the user will always see it as `None` if env exists, and then a 404 when it gets soft-deleted.

___

- _You can add a reference to an issue using hash followed by the issue number_
- _If a checklist item is to be ignored it must be struck through_
