### PR TITLE
Plutopulp/cli environment crud by name

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.4.0
     hooks:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer
@@ -10,15 +10,15 @@ repos:
     -   id: check-added-large-files
 
 -   repo: https://github.com/pycqa/flake8
-    rev: 5.0.4
+    rev: 6.0.0
     hooks:
     -   id: flake8
 -   repo: https://github.com/psf/black
-    rev: 22.10.0
+    rev: 23.1.0
     hooks:
     -   id: black
 -   repo: https://github.com/PyCQA/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
     -   id: isort
         args: ["--profile", "black", "--filter-files"]

--- a/pipeline/console/__init__.py
+++ b/pipeline/console/__init__.py
@@ -286,6 +286,14 @@ def main(args: Optional[List[str]] = None) -> int:
     environments_get_parser.add_argument(
         "name_or_id", help="The environment name or id to get"
     )
+
+    environments_get_parser.add_argument(
+        "-n",
+        help="Get the environment by name",
+        required=False,
+        action="store_true",
+        default=False,
+    )
     ##########
     # pipeline environments list
     ##########
@@ -325,6 +333,14 @@ def main(args: Optional[List[str]] = None) -> int:
         "name_or_id", help="The environment name or id to delete"
     )
 
+    environments_delete_parser.add_argument(
+        "-n",
+        help="Delete the environment by name",
+        required=False,
+        action="store_true",
+        default=False,
+    )
+
     ##########
     # pipeline environments update
     ##########
@@ -335,6 +351,13 @@ def main(args: Optional[List[str]] = None) -> int:
 
     environments_update_parser.add_argument(
         "name_or_id", help="The environment name or id to update"
+    )
+    environments_update_parser.add_argument(
+        "-n",
+        help="Update the environment by name",
+        required=False,
+        action="store_true",
+        default=False,
     )
 
     environments_update_sub_command = environments_update_parser.add_subparsers(
@@ -382,7 +405,6 @@ def main(args: Optional[List[str]] = None) -> int:
             tags_parser.print_help()
             return 1
     elif command == "environments":
-
         if (code := environments_command(args)) is None:
             if getattr(args, "sub-command") == "update":
                 environments_update_parser.print_help()

--- a/pipeline/console/environments.py
+++ b/pipeline/console/environments.py
@@ -22,9 +22,7 @@ def _get_environment(name_or_id: str, by_name=False) -> EnvironmentGet:
     remote_service = PipelineCloud(verbose=False)
     remote_service.authenticate()
 
-    url_config = ["/v2/environments", name_or_id]
-    separator = "/" if not by_name else "/by-name/"
-    url = separator.join(url_config)
+    url = f"/v2/environments/by-name/{name_or_id}" if by_name else f"/v2/environments/{name_or_id}"
 
     environment_information = EnvironmentGet.parse_obj(remote_service._get(url))
 

--- a/pipeline/console/environments.py
+++ b/pipeline/console/environments.py
@@ -22,7 +22,11 @@ def _get_environment(name_or_id: str, by_name=False) -> EnvironmentGet:
     remote_service = PipelineCloud(verbose=False)
     remote_service.authenticate()
 
-    url = f"/v2/environments/by-name/{name_or_id}" if by_name else f"/v2/environments/{name_or_id}"
+    url = (
+        f"/v2/environments/by-name/{name_or_id}"
+        if by_name
+        else f"/v2/environments/{name_or_id}"
+    )
 
     environment_information = EnvironmentGet.parse_obj(remote_service._get(url))
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pipeline-ai"
-version = "0.4.1"
+version = "0.4.2"
 
 description = "Pipelines for machine learning workloads."
 authors = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -294,7 +294,7 @@ def top_api_server(
     ).respond_with_json(environment_get.dict())
 
     httpserver.expect_request(
-        f"/v2/environments/{environment_get.name}",
+        f"/v2/environments/by-name/{environment_get.name}",
         method="GET",
         headers=dict(Authorization=f"Bearer {token}"),
     ).respond_with_json(environment_get.dict())

--- a/tests/test_cli/test_cli_environments.py
+++ b/tests/test_cli/test_cli_environments.py
@@ -29,7 +29,7 @@ def test_cli_environments_get(
     token: str,
 ):
     _set_testing_remote_compute_service(url, token)
-    assert environment_get == _get_environment(environment_get.name)
+    assert environment_get == _get_environment(environment_get.name, by_name=True)
     assert environment_get == _get_environment(environment_get.id)
 
     with pytest.raises(httpx.HTTPStatusError):
@@ -56,7 +56,7 @@ def test_cli_environments_delete(
     token: str,
 ):
     _set_testing_remote_compute_service(url, token)
-    _delete_environment(environment_get.name)
+    _delete_environment(environment_get.name, by_name=True)
     _delete_environment(environment_get.id)
 
     with pytest.raises(httpx.HTTPStatusError):
@@ -71,7 +71,6 @@ def test_cli_environments_update(
     url: str,
     token: str,
 ):
-
     # locking
     _set_testing_remote_compute_service(url, token)
     assert _update_environment_lock(environment_get.id, locked=True).locked


### PR DESCRIPTION
# Pull request outline

In this PR, we update the CLI to allow for retrieving, updating and deleting environments by environment name, by using an optional `-n` argument after the sub-command action.
### Example
Suppose we had an environment:
`{id: "environment_123", name: "slim"}`
You can retrieve the environment as usual, using the command `pipeline environments get environment_123` or, as of now, using `pipeline environments get -n slim`.
This holds also for the `update` and `delete` sub-commands, e.g. `pipeline environments update -n slim add my-package`.  

## Checklist:
- [ ] Docs updated
- [x] Tests written
- [ ] Check for breaking changes in Resource
- [x] Version bumped

Added:
- A list of new things

Changed:
- A list of things changed

## Related issues:
_none_

___

- _You can add a reference to an issue using hash followed by the issue number_
- _If a checklist item is to be ignored it must be struck through_
