### PR TITLE
Hotfix - Startup logic

### DIFF
--- a/pipeline/objects/graph.py
+++ b/pipeline/objects/graph.py
@@ -68,7 +68,6 @@ class Graph:
                 startup_variables[var.local_id] = var
 
         for node in self.nodes:
-
             node_inputs: List[Variable] = []
             node_function: Function = None
 
@@ -78,7 +77,7 @@ class Graph:
                     break
             if (
                 getattr(node_function.function, "__run_once__", False)
-                and not getattr(node_function.function, "__has_run__", False)
+                and getattr(node_function.function, "__has_run__", False)
             ) or not getattr(node_function.function, "__on_startup__", False):
                 continue
 
@@ -145,7 +144,6 @@ class Graph:
             running_variables[input_variables[i].local_id] = input
 
         for node in self.nodes:
-
             node_inputs: List[Variable] = []
             node_outputs: List[Variable] = []
             node_function: Function = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pipeline-ai"
-version = "0.4.3"
+version = "0.4.4"
 
 description = "Pipelines for machine learning workloads."
 authors = [


### PR DESCRIPTION
# Pull request outline
Theres a bug present in the startup logic where `run_once` is not triggering correctly in the startup function.

## Checklist:
- [x] Version bumped

Changed:
- Inverted has run logic

___

- _You can add a reference to an issue using hash followed by the issue number_
- _If a checklist item is to be ignored it must be struck through_
