### PR TITLE
Plutopulp/default and public environments

### DIFF
--- a/pipeline/console/__init__.py
+++ b/pipeline/console/__init__.py
@@ -289,10 +289,11 @@ def main(args: Optional[List[str]] = None) -> int:
     )
     # Positional arguments are required. We don't want to have to include name_or_id
     # when the default flag is set
-    "--default" not in sys.argv and environments_get_parser.add_argument(
-        "name_or_id",
-        help="The environment name or id to get",
-    )
+    if "--default" not in sys.argv:
+        environments_get_parser.add_argument(
+            "name_or_id",
+            help="The environment name or id to get",
+        )
 
     environments_get_parser.add_argument(
         "-n",

--- a/pipeline/console/__init__.py
+++ b/pipeline/console/__init__.py
@@ -282,9 +282,16 @@ def main(args: Optional[List[str]] = None) -> int:
         "get",
         help="Get environment information",
     )
-
     environments_get_parser.add_argument(
-        "name_or_id", help="The environment name or id to get"
+        "--default",
+        help="Get the default environment",
+        action="store_true",
+    )
+    # Positional arguments are required. We don't want to have to include name_or_id
+    # when the default flag is set
+    "--default" not in sys.argv and environments_get_parser.add_argument(
+        "name_or_id",
+        help="The environment name or id to get",
     )
 
     environments_get_parser.add_argument(
@@ -294,6 +301,7 @@ def main(args: Optional[List[str]] = None) -> int:
         action="store_true",
         default=False,
     )
+
     ##########
     # pipeline environments list
     ##########

--- a/pipeline/console/__init__.py
+++ b/pipeline/console/__init__.py
@@ -319,6 +319,11 @@ def main(args: Optional[List[str]] = None) -> int:
         default=0,
         type=int,
     )
+    environments_list_parser.add_argument(
+        "--public",
+        help="List publicly available environments",
+        action="store_true",
+    )
 
     ##########
     # pipeline environments delete
@@ -356,7 +361,6 @@ def main(args: Optional[List[str]] = None) -> int:
         "-n",
         help="Update the environment by name",
         required=False,
-        action="store_true",
         default=False,
     )
 

--- a/pipeline/console/environments.py
+++ b/pipeline/console/environments.py
@@ -35,8 +35,7 @@ def _get_environment(name_or_id, by_name=False) -> EnvironmentGet:
 
 
 def _list_environments(
-    skip: int,
-    limit: int,
+    skip: int, limit: int, public: bool = False
 ) -> Paginated[EnvironmentGet]:
     # TODO: Add in more filter fields
 
@@ -45,11 +44,7 @@ def _list_environments(
 
     response = remote_service._get(
         "/v2/environments",
-        params=dict(
-            skip=skip,
-            limit=limit,
-            order_by="created_at:desc",
-        ),
+        params=dict(skip=skip, limit=limit, order_by="created_at:desc", public=public),
     )
 
     paginated_environments = Paginated[EnvironmentGet].parse_obj(response)
@@ -204,8 +199,7 @@ def environments(args: argparse.Namespace) -> int:
         return 0
     elif sub_command in ["list", "ls"]:
         paginated_results = _list_environments(
-            getattr(args, "skip"),
-            getattr(args, "limit"),
+            getattr(args, "skip"), getattr(args, "limit"), args.public
         )
         table_string = _tabulate(paginated_results.data)
         print(table_string)

--- a/pipeline/console/environments.py
+++ b/pipeline/console/environments.py
@@ -41,10 +41,15 @@ def _list_environments(
 
     remote_service = PipelineCloud(verbose=False)
     remote_service.authenticate()
+    # The required query parameters
+    params = dict(skip=skip, limit=limit, order_by="created_at:desc")
+    # Do not include public param when not True
+    if public:
+        params["public"] = True
 
     response = remote_service._get(
         "/v2/environments",
-        params=dict(skip=skip, limit=limit, order_by="created_at:desc", public=public),
+        params=params,
     )
 
     paginated_environments = Paginated[EnvironmentGet].parse_obj(response)

--- a/pipeline/console/environments.py
+++ b/pipeline/console/environments.py
@@ -18,10 +18,12 @@ from pipeline.util.logging import _print
 environment_re_pattern = re.compile(r"^[0-9a-zA-Z]+[0-9a-zA-Z\_\-]+[0-9a-zA-Z]+$")
 
 
-def _get_environment(name_or_id: str, by_name=False) -> EnvironmentGet:
+def _get_environment(name_or_id, by_name=False) -> EnvironmentGet:
+    """Retrieve the environment given an environment name or ID.
+    This is called off the bat to resolve the ID and then make subsequent CRUD calls.
+    """
     remote_service = PipelineCloud(verbose=False)
     remote_service.authenticate()
-
     url = (
         f"/v2/environments/by-name/{name_or_id}"
         if by_name
@@ -29,7 +31,6 @@ def _get_environment(name_or_id: str, by_name=False) -> EnvironmentGet:
     )
 
     environment_information = EnvironmentGet.parse_obj(remote_service._get(url))
-
     return environment_information
 
 
@@ -84,21 +85,23 @@ def _create_environment(name: str, packages: List[str]) -> EnvironmentGet:
     return EnvironmentGet.parse_obj(environment_dict)
 
 
-def _delete_environment(name_or_id: str, by_name=False) -> None:
+def _delete_environment(id: str) -> None:
+    """Delete an environment by id. For deletion by name, resolve the environment ID
+    first."""
     remote_service = PipelineCloud(verbose=False)
     remote_service.authenticate()
 
-    environment_information = _get_environment(name_or_id, by_name=by_name)
-    remote_service._delete(f"/v2/environments/{environment_information.id}")
+    remote_service._delete(f"/v2/environments/{id}")
 
 
 def _update_environment(
-    name_or_id: str,
+    id: str,
     *,
     locked: bool = None,
     python_requirements: List[str] = None,
-    by_name=False,
 ) -> EnvironmentGet:
+    """Update an environment by id. For update by name, resolve the environment ID
+    first."""
     if locked is None and python_requirements is None:
         raise Exception(
             "Must un/lock or define python_requirements when updating an Environment"
@@ -106,65 +109,51 @@ def _update_environment(
     remote_service = PipelineCloud(verbose=False)
     remote_service.authenticate()
 
-    environment_information = _get_environment(name_or_id, by_name=by_name)
-
     update_schema = EnvironmentPatch(
         python_requirements=python_requirements, locked=locked
     )
     response = remote_service._patch(
-        f"/v2/environments/{environment_information.id}",
+        f"/v2/environments/{id}",
         update_schema.dict(),
     )
     return EnvironmentGet.parse_obj(response)
 
 
 def _add_packages_to_environment(
-    name_or_id: str,
+    environment: EnvironmentGet,
     new_packages: List[str],
-    by_name=False,
 ) -> EnvironmentGet:
-    environment_information = _get_environment(name_or_id, by_name=by_name)
-
-    current_packages = environment_information.python_requirements
+    current_packages = environment.python_requirements
     for new_package in new_packages:
         if new_package in current_packages:
             raise Exception(f"Package '{new_package}' is already in environment")
 
     current_packages.extend(new_packages)
 
-    return _update_environment(
-        environment_information.id, python_requirements=current_packages
-    )
+    return _update_environment(environment.id, python_requirements=current_packages)
 
 
 def _remove_packages_from_environment(
-    name_or_id: str,
+    environment: EnvironmentGet,
     packages: List[str],
-    by_name=False,
 ) -> EnvironmentGet:
-    environment_information = _get_environment(name_or_id, by_name=by_name)
-
-    current_packages = environment_information.python_requirements
+    current_packages = environment.python_requirements
     for package in packages:
         if package not in current_packages:
             raise Exception(f"Package '{package}' is not in environment")
 
     [current_packages.remove(package) for package in packages]
 
-    return _update_environment(
-        environment_information.id, python_requirements=current_packages
-    )
+    return _update_environment(environment.id, python_requirements=current_packages)
 
 
 def _update_environment_lock(
-    name_or_id: str, locked: bool, by_name=False
+    environment: EnvironmentGet, locked: bool
 ) -> EnvironmentGet:
-    environment_information = _get_environment(name_or_id, by_name=by_name)
-
-    if environment_information.locked == locked:
+    if environment.locked == locked:
         raise Exception(f"The environment already has locked={locked}")
 
-    return _update_environment(name_or_id, locked=locked, by_name=by_name)
+    return _update_environment(environment.id, locked=locked)
 
 
 def _tabulate(environments: List[EnvironmentGet]) -> str:
@@ -210,8 +199,7 @@ def environments(args: argparse.Namespace) -> int:
 
     elif sub_command == "get":
         name_or_id = getattr(args, "name_or_id", None)
-        by_name = getattr(args, "n", False)
-        environment = _get_environment(name_or_id, by_name=by_name)
+        environment = _get_environment(name_or_id, args.n)
         print(environment.json())
         return 0
     elif sub_command in ["list", "ls"]:
@@ -224,31 +212,31 @@ def environments(args: argparse.Namespace) -> int:
         return 0
     elif sub_command in ["delete", "rm"]:
         name_or_id: str = getattr(args, "name_or_id")
-        by_name = getattr(args, "n", False)
-        _delete_environment(name_or_id, by_name=by_name)
+        environment = _get_environment(name_or_id, args.n)
+        _delete_environment(environment)
         _print(f"Deleted {name_or_id}")
         return 0
     elif sub_command == "update":
         name_or_id: str = getattr(args, "name_or_id")
-        by_name = getattr(args, "n", False)
+        environment = _get_environment(name_or_id, args.n)
 
         update_command = getattr(args, "environments-update-sub-command")
 
         if update_command == "add":
             packages = getattr(args, "packages")
-            _add_packages_to_environment(name_or_id, packages, by_name=by_name)
+            _add_packages_to_environment(environment, packages)
             _print(f"Added packages to {name_or_id}")
             return 0
         elif update_command == "remove":
             packages = getattr(args, "packages")
-            _remove_packages_from_environment(name_or_id, packages, by_name=by_name)
+            _remove_packages_from_environment(environment, packages)
             _print(f"Removed packages from {name_or_id}")
             return 0
         elif update_command == "lock":
-            _update_environment_lock(name_or_id, True, by_name=by_name)
+            _update_environment_lock(environment, True)
             _print(f"Locked {name_or_id}")
             return 0
         elif update_command == "unlock":
-            _update_environment_lock(name_or_id, False, by_name=by_name)
+            _update_environment_lock(environment, False)
             _print(f"Unlocked {name_or_id}")
             return 0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pipeline-ai"
-version = "0.4.4"
+version = "0.4.5"
 
 description = "Pipelines for machine learning workloads."
 authors = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ os.environ["PIPELINE_CACHE"] = "./.tmp_cache/"
 import json
 from datetime import datetime
 from pathlib import Path
-from typing import Tuple
+from typing import List, Tuple
 
 import cloudpickle
 import dill
@@ -364,6 +364,21 @@ def top_api_server(
                 environment_get,
                 environment_get_add_package,
                 environment_get_rm_package,
+            ],
+        ).dict()
+    )
+    httpserver.expect_request(
+        f"/v2/environments",
+        method="GET",
+        headers=dict(Authorization=f"Bearer {token}"),
+        query_string="skip=0&limit=3&order_by=created_at%3Adesc&public=true",
+    ).respond_with_json(
+        Paginated[EnvironmentGet](
+            skip=0,
+            limit=3,
+            total=1,
+            data=[
+                environment_get_default,
             ],
         ).dict()
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,7 @@ import pytest
 from pytest_httpserver import HTTPServer
 from werkzeug.wrappers import Response
 
+from pipeline.api.environments import DEFAULT_ENVIRONMENT
 from pipeline.objects import (
     Graph,
     Pipeline,
@@ -91,6 +92,7 @@ def top_api_server(
     tag_create: PipelineTagCreate,
     # Environments
     environment_get: EnvironmentGet,
+    environment_get_default: EnvironmentGet,
     environment_get_locked: EnvironmentGet,
     environment_get_add_package: EnvironmentGet,
     environment_get_rm_package: EnvironmentGet,
@@ -292,6 +294,12 @@ def top_api_server(
         method="GET",
         headers=dict(Authorization=f"Bearer {token}"),
     ).respond_with_json(environment_get.dict())
+
+    httpserver.expect_request(
+        f"/v2/environments/{environment_get_default.id}",
+        method="GET",
+        headers=dict(Authorization=f"Bearer {token}"),
+    ).respond_with_json(environment_get_default.dict())
 
     httpserver.expect_request(
         f"/v2/environments/by-name/{environment_get.name}",
@@ -850,6 +858,19 @@ def environment_get_locked() -> EnvironmentGet:
     return EnvironmentGet(
         id="environment_1",
         name="test",
+        python_requirements=[
+            "dependency_1",
+            "dependency_2",
+        ],
+        locked=True,
+    )
+
+
+@pytest.fixture()
+def environment_get_default() -> EnvironmentGet:
+    return EnvironmentGet(
+        id=DEFAULT_ENVIRONMENT.id,
+        name=DEFAULT_ENVIRONMENT.name,
         python_requirements=[
             "dependency_1",
             "dependency_2",

--- a/tests/test_cli/test_cli_environments.py
+++ b/tests/test_cli/test_cli_environments.py
@@ -36,6 +36,16 @@ def test_cli_environments_get(
 
 
 @pytest.mark.usefixtures("top_api_server")
+def test_cli_get_get_default_environment(
+    environment_get_default: EnvironmentGet,
+    url: str,
+    token: str,
+):
+    _set_testing_remote_compute_service(url, token)
+    assert environment_get_default == _get_environment(None, default=True)
+
+
+@pytest.mark.usefixtures("top_api_server")
 def test_cli_environments_create(
     environment_create: EnvironmentCreate,
     environment_get: EnvironmentGet,

--- a/tests/test_cli/test_cli_environments.py
+++ b/tests/test_cli/test_cli_environments.py
@@ -56,7 +56,6 @@ def test_cli_environments_delete(
     token: str,
 ):
     _set_testing_remote_compute_service(url, token)
-    _delete_environment(environment_get.name, by_name=True)
     _delete_environment(environment_get.id)
 
     with pytest.raises(httpx.HTTPStatusError):
@@ -73,18 +72,18 @@ def test_cli_environments_update(
 ):
     # locking
     _set_testing_remote_compute_service(url, token)
-    assert _update_environment_lock(environment_get.id, locked=True).locked
+    assert _update_environment_lock(environment_get, locked=True).locked
 
     # deps
     assert (
         _add_packages_to_environment(
-            environment_get.id, ["dependency_3"]
+            environment_get, ["dependency_3"]
         ).python_requirements
         == environment_get_add_package.python_requirements
     )
     assert (
         _remove_packages_from_environment(
-            environment_get.id, ["dependency_1"]
+            environment_get, ["dependency_1"]
         ).python_requirements
         == environment_get_rm_package.python_requirements
     )

--- a/tests/test_cli/test_cli_environments.py
+++ b/tests/test_cli/test_cli_environments.py
@@ -9,6 +9,7 @@ from pipeline.console.environments import (
     _delete_environment,
     _get_environment,
     _list_environments,
+    _remove_packages_from_environment,
     _update_environment_lock,
 )
 from pipeline.schemas.environment import EnvironmentCreate, EnvironmentGet
@@ -72,30 +73,46 @@ def test_cli_environments_delete(
 
 
 @pytest.mark.usefixtures("top_api_server")
-def test_cli_environments_update(
+def test_cli_environments_update_lock(
     environment_get: EnvironmentGet,
-    environment_get_add_package: EnvironmentGet,
-    environment_get_rm_package: EnvironmentGet,
     url: str,
     token: str,
 ):
-    # locking
     _set_testing_remote_compute_service(url, token)
     assert _update_environment_lock(environment_get, locked=True).locked
 
-    # deps
+
+@pytest.mark.usefixtures("top_api_server")
+def test_cli_environments_add_packages(
+    environment_get: EnvironmentGet,
+    environment_get_add_package: EnvironmentGet,
+    url: str,
+    token: str,
+):
+    _set_testing_remote_compute_service(url, token)
     assert (
         _add_packages_to_environment(
             environment_get, ["dependency_3"]
         ).python_requirements
         == environment_get_add_package.python_requirements
     )
-    # assert (
-    #     _remove_packages_from_environment(
-    #         environment_get, ["dependency_1"]
-    #     ).python_requirements
-    #     == environment_get_rm_package.python_requirements
-    # )
+
+
+@pytest.mark.usefixtures("top_api_server")
+def test_cli_environments_remove_packages(
+    environment_get: EnvironmentGet,
+    environment_get_rm_package: EnvironmentGet,
+    url: str,
+    token: str,
+):
+    _set_testing_remote_compute_service(url, token)
+
+    assert (
+        _remove_packages_from_environment(
+            environment_get, ["dependency_1"]
+        ).python_requirements
+        == environment_get_rm_package.python_requirements
+    )
 
 
 @pytest.mark.usefixtures("top_api_server")

--- a/tests/test_cli/test_cli_environments.py
+++ b/tests/test_cli/test_cli_environments.py
@@ -118,3 +118,21 @@ def test_cli_environments_list(
             environment_get_rm_package,
         ],
     ) == _list_environments(skip=1, limit=3)
+
+
+@pytest.mark.usefixtures("top_api_server")
+def test_cli_environments_list_public(
+    environment_get_default: EnvironmentGet,
+    url: str,
+    token: str,
+):
+    _set_testing_remote_compute_service(url, token)
+
+    assert Paginated[EnvironmentGet](
+        skip=0,
+        limit=3,
+        total=1,
+        data=[
+            environment_get_default,
+        ],
+    ) == _list_environments(skip=0, limit=3, public=True)

--- a/tests/test_cli/test_cli_environments.py
+++ b/tests/test_cli/test_cli_environments.py
@@ -9,7 +9,6 @@ from pipeline.console.environments import (
     _delete_environment,
     _get_environment,
     _list_environments,
-    _remove_packages_from_environment,
     _update_environment_lock,
 )
 from pipeline.schemas.environment import EnvironmentCreate, EnvironmentGet
@@ -81,12 +80,12 @@ def test_cli_environments_update(
         ).python_requirements
         == environment_get_add_package.python_requirements
     )
-    assert (
-        _remove_packages_from_environment(
-            environment_get, ["dependency_1"]
-        ).python_requirements
-        == environment_get_rm_package.python_requirements
-    )
+    # assert (
+    #     _remove_packages_from_environment(
+    #         environment_get, ["dependency_1"]
+    #     ).python_requirements
+    #     == environment_get_rm_package.python_requirements
+    # )
 
 
 @pytest.mark.usefixtures("top_api_server")


### PR DESCRIPTION
# Pull request outline

In this PR we we add to the environments CLI, where we:
- Refactor existing logic for CRUD by_name on environments by resolving/fetching the environment right off the bat, by `name` or `id` and then use the ID of the resulting object to make further actions on that environment.
- Add logic for listing publicly available environments, e.g. `pipeline environments list --public`
- Add logic for retrieving the default environment, e.g. `pipeline environments get --default`

Note that the default environment configuration `(id, name)` is always expected to be defined in this client, i.e. `pipeline-ai` and not in the `API` itself, even if the environment object associated with this configuration, is defined in the API. This lets the client choose what the default environment should be. Just something to note.
Further, the way we have implemented getting the default environment isn't the prettiest, where we conditionally add the required parser argument `name_or_id` depending on whether the `--default` flag has been set. This makes the UX of the CLI potentially nicer, but the following for instance, would keep things less convoluted: `pipeline environments get-default`. 


## Checklist:
- [ ] Docs updated
- [x] Tests written
- [x] Check for breaking changes in Resource
- [x] Version bumped


___

- _You can add a reference to an issue using hash followed by the issue number_
- _If a checklist item is to be ignored it must be struck through_
