### PR TITLE
Support future `RunState` values

### DIFF
--- a/pipeline/cloud/schemas/runs.py
+++ b/pipeline/cloud/schemas/runs.py
@@ -64,7 +64,10 @@ class RunState(int, Enum):
         if isinstance(v, str):
             return cls.lookup[v]
         elif isinstance(v, int):
-            return getattr(cls, cls.value_lookup[v])
+            print(f"ROSSLOG {v=}")
+            res = getattr(cls, cls.value_lookup[v])
+            print(f"ROSSLOG {res=}")
+            return res
         else:
             raise ValueError(f"Invalid value: {v}")
 

--- a/pipeline/cloud/schemas/runs.py
+++ b/pipeline/cloud/schemas/runs.py
@@ -62,12 +62,17 @@ class RunState(int, Enum):
             ...
 
         if isinstance(v, str):
-            return cls.lookup[v]
+            try:
+                state = cls.lookup[v]
+            except KeyError:
+                state = cls.unknown
+            return state
         elif isinstance(v, int):
-            print(f"ROSSLOG {v=}")
-            res = getattr(cls, cls.value_lookup[v])
-            print(f"ROSSLOG {res=}")
-            return res
+            try:
+                state = getattr(cls, cls.value_lookup[v])
+            except KeyError:
+                state = cls.unknown
+            return state
         else:
             raise ValueError(f"Invalid value: {v}")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pipeline-ai"
-version = "1.0.13"
+version = "1.0.14"
 description = "Pipelines for machine learning workloads."
 authors = [
   "Paul Hetherington <ph@mystic.ai>",


### PR DESCRIPTION
# Pull request outline

Currently if a new run state is added to the `RunState` enum, clients using an older version of the library will get a deserialisation error if a new state is returned that they're unaware of. This PR makes adding new run states backwards compatible by returning `RunState.unknown` if the `RunState` returned by the API is new/unknown.


## Checklist:
- [x] Version bumped
