### PR TITLE
fix

### DIFF
--- a/pipeline/cloud/compute_requirements.py
+++ b/pipeline/cloud/compute_requirements.py
@@ -59,11 +59,13 @@ class Accelerator(str, Enum):
             [Accelerator.nvidia_v100_32gb],
             [Accelerator.nvidia_l4],
             [Accelerator.nvidia_a5000],
+            [Accelerator.nvidia_all],
+            [Accelerator.cpu],
         ]
 
     def max_memory_mb(self) -> int:
         return defaultdict(
-            lambda: 16_000,
+            lambda: 10_000,
             {
                 Accelerator.nvidia_t4: 16_000,
                 Accelerator.nvidia_a100: 40_000,


### PR DESCRIPTION
https://linear.app/mystic-ai/issue/PC-822/accelerator-validation-does-not-allow-nvidia-all
https://linear.app/mystic-ai/issue/PC-821/accelerator-validation-does-not-allow-cpu