### PR TITLE
pipeline metadata field alias

### DIFF
--- a/pipeline/cloud/schemas/pipelines.py
+++ b/pipeline/cloud/schemas/pipelines.py
@@ -1,6 +1,8 @@
 import typing as t
 from datetime import datetime
 
+from pydantic import Field
+
 from pipeline.cloud.compute_requirements import Accelerator
 from pipeline.cloud.schemas import BaseModel
 from pipeline.cloud.schemas.runs import RunIOType
@@ -45,7 +47,10 @@ class PipelineGet(BaseModel):
     input_variables: t.List[IOVariable]
     output_variables: t.List[IOVariable]
 
-    _metadata: t.Optional[dict]
+    metadata: t.Optional[dict] = Field(alias="_metadata")
+
+    class Config(BaseModel.Config):
+        allow_population_by_field_name = True
 
 
 class PipelinePatch(BaseModel):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pipeline-ai"
-version = "1.0.25"
+version = "1.0.26"
 description = "Pipelines for machine learning workloads."
 authors = [
   "Paul Hetherington <ph@mystic.ai>",


### PR DESCRIPTION
# Pull request outline

Since Pydantic filters out field names which begin with an underscore, and we want to return a pipelines' metadata as `_metadata: {...}`, we get around this by creating an alias for the field. 

## Checklist:
- [x] Check for breaking changes in Resource
- [x] Version bumped

___

- _You can add a reference to an issue using hash followed by the issue number_
- _If a checklist item is to be ignored it must be struck through_
