### PR TITLE
PC-852 - error reporting

### DIFF
--- a/pipeline/cloud/schemas/runs.py
+++ b/pipeline/cloud/schemas/runs.py
@@ -201,7 +201,7 @@ class RunInput(BaseModel):
     file_url: t.Optional[str]
 
 
-class ContainerRunError(str, Enum):
+class ContainerRunErrorType(str, Enum):
     input_error = "input_error"
     cuda_oom = "cuda_oom"
     cuda_error = "cuda_error"
@@ -212,6 +212,12 @@ class ContainerRunError(str, Enum):
     unknown = "unknown"
 
 
+class ContainerRunError(BaseModel):
+    type: ContainerRunErrorType
+    message: str
+    traceback: t.Optional[str]
+
+
 class ContainerRunCreate(BaseModel):
     inputs: t.List[RunInput]
 
@@ -219,8 +225,6 @@ class ContainerRunCreate(BaseModel):
 class ContainerRunResult(BaseModel):
     outputs: t.Optional[t.List[RunOutput]]
     error: t.Optional[ContainerRunError]
-    error_message: t.Optional[str]
-    error_traceback: t.Optional[str]
 
     def outputs_formatted(self) -> t.List[t.Any]:
         # return [output.value for output in self.outputs]

--- a/pipeline/cloud/schemas/runs.py
+++ b/pipeline/cloud/schemas/runs.py
@@ -207,6 +207,7 @@ class ContainerRunError(str, Enum):
     cuda_error = "cuda_error"
     oom = "oom"
     pipeline_error = "pipeline_error"
+    startup_error = "startup_error"
     unknown = "unknown"
 
 

--- a/pipeline/cloud/schemas/runs.py
+++ b/pipeline/cloud/schemas/runs.py
@@ -208,6 +208,7 @@ class ContainerRunError(str, Enum):
     oom = "oom"
     pipeline_error = "pipeline_error"
     startup_error = "startup_error"
+    pipeline_loading = "pipeline_loading"
     unknown = "unknown"
 
 

--- a/pipeline/cloud/schemas/runs.py
+++ b/pipeline/cloud/schemas/runs.py
@@ -218,6 +218,7 @@ class ContainerRunResult(BaseModel):
     outputs: t.Optional[t.List[RunOutput]]
     error: t.Optional[ContainerRunError]
     error_message: t.Optional[str]
+    error_traceback: t.Optional[str]
 
     def outputs_formatted(self) -> t.List[t.Any]:
         # return [output.value for output in self.outputs]

--- a/pipeline/cloud/schemas/runs.py
+++ b/pipeline/cloud/schemas/runs.py
@@ -206,6 +206,7 @@ class ContainerRunError(str, Enum):
     cuda_oom = "cuda_oom"
     cuda_error = "cuda_error"
     oom = "oom"
+    pipeline_error = "pipeline_error"
     unknown = "unknown"
 
 

--- a/pipeline/container/manager.py
+++ b/pipeline/container/manager.py
@@ -64,15 +64,14 @@ class Manager:
         self.pipeline_state = pipeline_schemas.PipelineState.loading
         try:
             self.pipeline._startup()
-        except Exception as e:
+        except Exception:
             tb = traceback.format_exc()
             logger.exception("Exception raised during pipeline execution")
             self.pipeline_state = pipeline_schemas.PipelineState.failed
             self.pipeline_state_message = tb
-            raise RunnableError(exception=e, traceback=tb)
-
-        self.pipeline_state = pipeline_schemas.PipelineState.loaded
-        logger.info("Pipeline started successfully")
+        else:
+            self.pipeline_state = pipeline_schemas.PipelineState.loaded
+            logger.info("Pipeline started successfully")
 
     def _resolve_file_variable_to_local(
         self,

--- a/pipeline/container/manager.py
+++ b/pipeline/container/manager.py
@@ -65,10 +65,11 @@ class Manager:
         try:
             self.pipeline._startup()
         except Exception as e:
-            logger.exception(e)
+            tb = traceback.format_exc()
+            logger.exception("Exception raised during pipeline execution")
             self.pipeline_state = pipeline_schemas.PipelineState.failed
-            self.pipeline_state_message = str(e)
-            raise e
+            self.pipeline_state_message = tb
+            raise RunnableError(exception=e, traceback=tb)
 
         self.pipeline_state = pipeline_schemas.PipelineState.loaded
         logger.info("Pipeline started successfully")

--- a/pipeline/container/manager.py
+++ b/pipeline/container/manager.py
@@ -2,6 +2,7 @@ import hashlib
 import importlib
 import logging
 import os
+import traceback
 import typing as t
 import urllib.parse
 from pathlib import Path
@@ -12,6 +13,7 @@ import validators
 
 from pipeline.cloud.schemas import pipelines as pipeline_schemas
 from pipeline.cloud.schemas import runs as run_schemas
+from pipeline.exceptions import RunnableError
 from pipeline.objects import Directory, File, Graph
 from pipeline.objects.graph import InputSchema
 
@@ -197,4 +199,8 @@ class Manager:
 
     def run(self, input_data: t.List[run_schemas.RunInput] | None) -> t.Any:
         args = self._parse_inputs(input_data, self.pipeline)
-        return self.pipeline.run(*args)
+        try:
+            result = self.pipeline.run(*args)
+        except Exception as exc:
+            raise RunnableError(exception=exc, traceback=traceback.format_exc())
+        return result

--- a/pipeline/container/routes/v4/runs.py
+++ b/pipeline/container/routes/v4/runs.py
@@ -68,7 +68,7 @@ async def run(
         response_schema = run_schemas.ContainerRunResult(
             outputs=None,
             error=run_schemas.ContainerRunError.pipeline_error,
-            error_message=str(run_output),
+            error_message=repr(run_output.exception),
             error_traceback=run_output.traceback,
         )
     elif isinstance(run_output, Exception):

--- a/pipeline/container/routes/v4/runs.py
+++ b/pipeline/container/routes/v4/runs.py
@@ -53,6 +53,7 @@ async def run(
             outputs=None,
             error=run_schemas.ContainerRunError.pipeline_error,
             error_message=str(run_output),
+            error_traceback=run_output.traceback,
         )
     elif isinstance(run_output, Exception):
         response.status_code = 500

--- a/pipeline/container/routes/v4/runs.py
+++ b/pipeline/container/routes/v4/runs.py
@@ -4,7 +4,7 @@ import logging
 from fastapi import APIRouter, Request, Response
 
 from pipeline.cloud.schemas import runs as run_schemas
-from pipeline.exceptions import RunInputException
+from pipeline.exceptions import RunInputException, RunnableError
 
 logger = logging.getLogger("uvicorn")
 router = APIRouter(prefix="/runs")
@@ -47,7 +47,13 @@ async def run(
             error=run_schemas.ContainerRunError.input_error,
             error_message=run_output.message,
         )
-
+    elif isinstance(run_output, RunnableError):
+        # response.status_code = 200
+        response_schema = run_schemas.ContainerRunResult(
+            outputs=None,
+            error=run_schemas.ContainerRunError.pipeline_error,
+            error_message=str(run_output),
+        )
     elif isinstance(run_output, Exception):
         response.status_code = 500
         response_schema = run_schemas.ContainerRunResult(

--- a/pipeline/container/routes/v4/runs.py
+++ b/pipeline/container/routes/v4/runs.py
@@ -38,17 +38,21 @@ async def run(
         logger.info("Pipeline loading")
         return run_schemas.ContainerRunResult(
             outputs=None,
-            error=run_schemas.ContainerRunError.pipeline_loading,
-            error_message="Pipeline is still loading",
+            error=run_schemas.ContainerRunError(
+                type=run_schemas.ContainerRunErrorType.pipeline_loading,
+                message="Pipeline is still loading",
+            ),
         )
 
     if manager.pipeline_state == pipeline_schemas.PipelineState.failed:
         logger.info("Pipeline failed to load")
         return run_schemas.ContainerRunResult(
             outputs=None,
-            error=run_schemas.ContainerRunError.startup_error,
-            error_message="Pipeline failed to load",
-            error_traceback=manager.pipeline_state_message,
+            error=run_schemas.ContainerRunError(
+                type=run_schemas.ContainerRunErrorType.startup_error,
+                message="Pipeline failed to load",
+                traceback=manager.pipeline_state_message,
+            ),
         )
 
     execution_queue: asyncio.Queue = request.app.state.execution_queue
@@ -60,23 +64,29 @@ async def run(
         response.status_code = 400
         response_schema = run_schemas.ContainerRunResult(
             outputs=None,
-            error=run_schemas.ContainerRunError.input_error,
-            error_message=run_output.message,
+            error=run_schemas.ContainerRunError(
+                type=run_schemas.ContainerRunErrorType.input_error,
+                message=run_output.message,
+            ),
         )
     elif isinstance(run_output, RunnableError):
         # response.status_code = 200
         response_schema = run_schemas.ContainerRunResult(
             outputs=None,
-            error=run_schemas.ContainerRunError.pipeline_error,
-            error_message=repr(run_output.exception),
-            error_traceback=run_output.traceback,
+            error=run_schemas.ContainerRunError(
+                type=run_schemas.ContainerRunErrorType.pipeline_error,
+                message=repr(run_output.exception),
+                traceback=run_output.traceback,
+            ),
         )
     elif isinstance(run_output, Exception):
         response.status_code = 500
         response_schema = run_schemas.ContainerRunResult(
             outputs=None,
-            error=run_schemas.ContainerRunError.unknown,
-            error_message=str(run_output),
+            error=run_schemas.ContainerRunError(
+                type=run_schemas.ContainerRunErrorType.unknown,
+                message=str(run_output),
+            ),
         )
     else:
         outputs = [
@@ -90,7 +100,6 @@ async def run(
         response_schema = run_schemas.ContainerRunResult(
             outputs=outputs,
             error=None,
-            error_message=None,
         )
 
     return response_schema

--- a/pipeline/container/routes/v4/runs.py
+++ b/pipeline/container/routes/v4/runs.py
@@ -47,7 +47,8 @@ async def run(
         return run_schemas.ContainerRunResult(
             outputs=None,
             error=run_schemas.ContainerRunError.startup_error,
-            error_message=manager.pipeline_state_message,
+            error_message="Pipeline failed to load",
+            error_traceback=manager.pipeline_state_message,
         )
 
     execution_queue: asyncio.Queue = request.app.state.execution_queue

--- a/pipeline/container/startup.py
+++ b/pipeline/container/startup.py
@@ -98,9 +98,6 @@ async def execution_handler(execution_queue: asyncio.Queue, manager: Manager) ->
         try:
             args, response_queue = await execution_queue.get()
 
-            logger.info("Got run request")
-            logger.info(f"Pipeline state: {manager.pipeline_state}")
-
             try:
                 output = await run_in_threadpool(manager.run, input_data=args)
             except Exception as e:

--- a/pipeline/container/startup.py
+++ b/pipeline/container/startup.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 import os
+import threading
 import time
 import traceback
 import uuid
@@ -95,7 +96,7 @@ def setup_oapi(app: FastAPI) -> None:
 
 
 async def execution_handler(execution_queue: asyncio.Queue, manager: Manager) -> None:
-    run_in_threadpool(manager.startup)
+    threading.Thread(target=manager.startup).start()
 
     while True:
         try:

--- a/pipeline/container/startup.py
+++ b/pipeline/container/startup.py
@@ -92,10 +92,7 @@ def setup_oapi(app: FastAPI) -> None:
 
 
 async def execution_handler(execution_queue: asyncio.Queue, manager: Manager) -> None:
-    try:
-        await run_in_threadpool(manager.startup)
-    except Exception:
-        logger.exception("Exception raised during pipeline startup")
+    await run_in_threadpool(manager.startup)
 
     while True:
         try:

--- a/pipeline/container/startup.py
+++ b/pipeline/container/startup.py
@@ -16,6 +16,7 @@ from pipeline.cloud.schemas import pipelines as pipeline_schemas
 from pipeline.container.manager import Manager
 from pipeline.container.routes import router
 from pipeline.container.status import router as status_router
+from pipeline.exceptions import RunnableError
 
 logger = logging.getLogger("uvicorn")
 
@@ -94,7 +95,7 @@ def setup_oapi(app: FastAPI) -> None:
 
 
 async def execution_handler(execution_queue: asyncio.Queue, manager: Manager) -> None:
-    await run_in_threadpool(manager.startup)
+    run_in_threadpool(manager.startup)
 
     while True:
         try:
@@ -121,7 +122,7 @@ async def execution_handler(execution_queue: asyncio.Queue, manager: Manager) ->
             try:
                 output = await run_in_threadpool(manager.run, input_data=args)
             except Exception as e:
-                logger.exception(e)
+                logger.exception("Exception raised during pipeline execution")
                 response_queue.put_nowait(e)
                 continue
             response_queue.put_nowait(output)

--- a/pipeline/exceptions/__init__.py
+++ b/pipeline/exceptions/__init__.py
@@ -7,3 +7,19 @@ class RunInputException(Exception):
 
     def __init__(self, message):
         self.message = message
+
+
+class RunnableError(Exception):
+    """Exception raised during the execution of a pipeline."""
+
+    def __init__(
+        self,
+        exception: Exception,
+        traceback: str | None,
+    ) -> None:
+        self.exception = exception
+        self.traceback = traceback
+        super().__init__(self.exception, self.traceback)
+
+    def __str__(self):
+        return f"RunnableError({repr(self.exception)})"


### PR DESCRIPTION
# Pull request outline

Adds error reporting to users (both during graph startup and run time).

**Question: maybe it would be neater to nest all error fields inside a single `error` object?**

### Some examples:

Success

```bash
{
	"outputs": [
		{
			"type": "string",
			"value": "what a lovely day outside, perfect for",
			"file": null
		}
	],
	"error": null,
	"error_message": null,
	"error_traceback": null,
	"id": "run_379bab167cba48fe913cf10c80d05ca9",
	"created_at": 1699630559.575587,
	"updated_at": 1699630559.575587,
	"pipeline_id": "pipeline_081902843d3f468f9078b692784eeebe"
}
```

User pipeline failure

```bash
{
	"outputs": null,
	"error": "pipeline_error",
	"error_message": "TypeError('this is a made up error')",
	"error_traceback": "Traceback (most recent call last):\n  File \"/usr/local/lib/python3.10/site-packages/pipeline/container/manager.py\", line 214, in run\n    result = self.pipeline.run(*args)\n  File \"/usr/local/lib/python3.10/site-packages/pipeline/objects/graph.py\", line 700, in run\n    output = node_function.function(*function_inputs)\n  File \"/app/./my_pipeline.py\", line 6, in error\n    raise TypeError(\"this is a made up error\")\nTypeError: this is a made up error\n",
	"id": "run_198332046615422eb894d3a537fbea56",
	"created_at": 1699630737.689476,
	"updated_at": 1699630737.689476,
	"pipeline_id": "pipeline_9922f0390e8b43b28578a1a78fcabb0a"
}
```

Error during pipeline startup

```bash
{
	"outputs": null,
	"error": "startup_error",
	"error_message": "Pipeline failed to load",
	"error_traceback": "Traceback (most recent call last):\n  File \"/usr/local/lib/python3.10/site-packages/pipeline/container/manager.py\", line 67, in startup\n    self.pipeline._startup()\n  File \"/usr/local/lib/python3.10/site-packages/pipeline/objects/graph.py\", line 611, in _startup\n    node_function.function(node_function.class_instance, *function_inputs)\n  File \"/app/./my_pipeline.py\", line 8, in load\n    raise TypeError(\"this is an error in load function\")\nTypeError: this is an error in load function\n",
	"id": "run_28b2f007e1494c708682e6be39d53642",
	"created_at": 1699630885.210323,
	"updated_at": 1699630885.210323,
	"pipeline_id": "pipeline_c348b728d3354ca59d450778a25da94a"
}
```