### PR TITLE
Support run output files

### DIFF
--- a/pipeline/cloud/schemas/files.py
+++ b/pipeline/cloud/schemas/files.py
@@ -52,6 +52,7 @@ class MultipartFileUploadFinaliseCreate(BaseModel):
 class UploadFileUsingPresignedUrl(BaseModel):
     local_file_path: str
     upload_url: str
+    upload_fields: dict[str, str]
 
 
 class UploadFilesToRemoteStorageCreate(BaseModel):

--- a/pipeline/cloud/schemas/files.py
+++ b/pipeline/cloud/schemas/files.py
@@ -47,3 +47,12 @@ class MultipartFileUploadFinaliseCreate(BaseModel):
     upload_id: str
     # The metadata obtained from each part of the file upload
     multipart_metadata: list[MultipartFileUploadMetadata]
+
+
+class UploadFileUsingPresignedUrl(BaseModel):
+    local_file_path: str
+    upload_url: str
+
+
+class UploadFilesToRemoteStorageCreate(BaseModel):
+    files: list[UploadFileUsingPresignedUrl]

--- a/pipeline/cloud/schemas/runs.py
+++ b/pipeline/cloud/schemas/runs.py
@@ -159,7 +159,7 @@ class RunIOType(str, Enum):
 class RunOutputFile(BaseModel):
     name: str
     path: str
-    url: str
+    url: t.Optional[str]
     size: int
 
 

--- a/pipeline/container/docker_templates/template_1.txt
+++ b/pipeline/container/docker_templates/template_1.txt
@@ -3,7 +3,7 @@ FROM python:{python_version}-slim
 WORKDIR /app
 
 RUN apt update -y
-RUN pip install -U pip
+RUN pip install -U pip setuptools wheel
 
 # Install serving packages
 RUN pip install -U fastapi==0.103.2 uvicorn==0.15.0 \

--- a/pipeline/container/routes/v4/files.py
+++ b/pipeline/container/routes/v4/files.py
@@ -57,4 +57,6 @@ async def _upload_file_using_presigned_url(
 ):
     logger.info(f"Uploading {file.local_file_path} to {file.upload_url}")
     with open(file.local_file_path, "rb") as f:
-        await client.post(file.upload_url, files={"upload-file": f})
+        await client.post(
+            file.upload_url, files={"upload-file": f}, data=file.upload_fields
+        )

--- a/pipeline/container/routes/v4/files.py
+++ b/pipeline/container/routes/v4/files.py
@@ -39,11 +39,12 @@ async def file_upload(
     "/upload-to-storage",
     status_code=status.HTTP_201_CREATED,
 )
-async def upload_local_file_to_storage(
+async def upload_local_files_to_storage(
     payload: files_schemas.UploadFilesToRemoteStorageCreate,
 ):
     """For list of files in the request, upload the file from local storage to
-    remote storage, using presigned URL.
+    remote storage, using presigned URL. Files are uploaded in parallel for
+    efficiency.
     """
     async with httpx.AsyncClient() as client:
         await asyncio.gather(

--- a/pipeline/container/routes/v4/runs.py
+++ b/pipeline/container/routes/v4/runs.py
@@ -1,5 +1,10 @@
 import asyncio
+import io
 import logging
+import os
+import shutil
+import uuid
+from pathlib import Path
 
 from fastapi import APIRouter, Request, Response
 
@@ -7,6 +12,7 @@ from pipeline.cloud.schemas import pipelines as pipeline_schemas
 from pipeline.cloud.schemas import runs as run_schemas
 from pipeline.container.manager import Manager
 from pipeline.exceptions import RunInputException, RunnableError
+from pipeline.objects.graph import File
 
 logger = logging.getLogger("uvicorn")
 router = APIRouter(prefix="/runs")
@@ -60,46 +66,104 @@ async def run(
     response_queue: asyncio.Queue = asyncio.Queue()
     execution_queue.put_nowait((run_create.inputs, response_queue))
     run_output = await response_queue.get()
+
+    response_schema, response.status_code = _generate_run_result(run_output)
+    return response_schema
+
+
+def _generate_run_result(run_output) -> tuple[run_schemas.ContainerRunResult, int]:
     if isinstance(run_output, RunInputException):
-        response.status_code = 400
-        response_schema = run_schemas.ContainerRunResult(
-            outputs=None,
-            error=run_schemas.ContainerRunError(
-                type=run_schemas.ContainerRunErrorType.input_error,
-                message=run_output.message,
+        return (
+            run_schemas.ContainerRunResult(
+                outputs=None,
+                error=run_schemas.ContainerRunError(
+                    type=run_schemas.ContainerRunErrorType.input_error,
+                    message=run_output.message,
+                ),
             ),
+            400,
         )
     elif isinstance(run_output, RunnableError):
-        # response.status_code = 200
-        response_schema = run_schemas.ContainerRunResult(
-            outputs=None,
-            error=run_schemas.ContainerRunError(
-                type=run_schemas.ContainerRunErrorType.pipeline_error,
-                message=repr(run_output.exception),
-                traceback=run_output.traceback,
+        return (
+            run_schemas.ContainerRunResult(
+                outputs=None,
+                error=run_schemas.ContainerRunError(
+                    type=run_schemas.ContainerRunErrorType.pipeline_error,
+                    message=repr(run_output.exception),
+                    traceback=run_output.traceback,
+                ),
             ),
+            200,
         )
     elif isinstance(run_output, Exception):
-        response.status_code = 500
-        response_schema = run_schemas.ContainerRunResult(
-            outputs=None,
-            error=run_schemas.ContainerRunError(
-                type=run_schemas.ContainerRunErrorType.unknown,
-                message=str(run_output),
+        return (
+            run_schemas.ContainerRunResult(
+                outputs=None,
+                error=run_schemas.ContainerRunError(
+                    type=run_schemas.ContainerRunErrorType.unknown,
+                    message=str(run_output),
+                ),
             ),
+            500,
         )
     else:
-        outputs = [
-            run_schemas.RunOutput(
-                type=run_schemas.RunIOType.from_object(output),
-                value=output,
-                file=None,
-            )
-            for output in run_output
-        ]
-        response_schema = run_schemas.ContainerRunResult(
-            outputs=outputs,
-            error=None,
+        outputs = _parse_run_outputs(run_output)
+        return (
+            run_schemas.ContainerRunResult(
+                outputs=outputs,
+                error=None,
+            ),
+            200,
         )
 
-    return response_schema
+
+def _parse_run_outputs(run_outputs):
+    outputs = []
+    for output in run_outputs:
+        output_type = run_schemas.RunIOType.from_object(output)
+        if output_type == run_schemas.RunIOType.file:
+            file_schema = _save_run_file(output)
+            outputs.append(
+                run_schemas.RunOutput(type=output_type, value=None, file=file_schema)
+            )
+        else:
+            outputs.append(
+                run_schemas.RunOutput(type=output_type, value=output, file=None)
+            )
+    return outputs
+
+
+def _save_run_file(file: File | io.BufferedIOBase) -> run_schemas.RunOutputFile:
+    # ensure we save the file somewhere unique on the file system so it doesn't
+    # get overwritten by another run
+    uuid_path = str(uuid.uuid4())
+    output_path = Path(f"/tmp/run_files/{uuid_path}")
+    output_path.mkdir(parents=True, exist_ok=True)
+
+    if isinstance(file, File):
+        # should always exist
+        assert file.path
+        file_name = file.path.name
+        output_file = output_path / file_name
+        file_size = os.stat(file.path).st_size
+        # copy file to new output location
+        shutil.copyfile(file.path, output_file)
+    else:
+        file_name = getattr(
+            file,
+            "name",
+            str(uuid.uuid4()),
+        )
+        try:
+            file_size = file.seek(0, os.SEEK_END)
+        except Exception:
+            file_size = -1
+            logger.warning(f"Could not get size of type {type(file)}")
+        # write file to new output location
+        output_file = output_path / file_name
+        output_file.write_bytes(file.read())
+
+    file_schema = run_schemas.RunOutputFile(
+        name=file_name, path=str(output_file), size=file_size, url=None
+    )
+    return file_schema

--- a/pipeline/container/routes/v4/runs.py
+++ b/pipeline/container/routes/v4/runs.py
@@ -121,6 +121,8 @@ def _parse_run_outputs(run_outputs):
     outputs = []
     for output in run_outputs:
         output_type = run_schemas.RunIOType.from_object(output)
+        print(f"ROSSLOG {output=}")
+        print(f"ROSSLOG {output_type=}")
         if output_type == run_schemas.RunIOType.file:
             file_schema = _save_run_file(output)
             outputs.append(

--- a/pipeline/container/routes/v4/runs.py
+++ b/pipeline/container/routes/v4/runs.py
@@ -121,8 +121,6 @@ def _parse_run_outputs(run_outputs):
     outputs = []
     for output in run_outputs:
         output_type = run_schemas.RunIOType.from_object(output)
-        print(f"ROSSLOG {output=}")
-        print(f"ROSSLOG {output_type=}")
         if output_type == run_schemas.RunIOType.file:
             file_schema = _save_run_file(output)
             outputs.append(


### PR DESCRIPTION
# Pull request outline

Support file output types from runs.

Also add an endpoint to resource to allow it to upload local files to a remote storage location using a presigned URL. (At the moment, we do not delete the local file after it's been uploaded to remote storage but could add this in easily if desired.)