### PR TITLE
Backwards Compatibility for Migrated Pipelines

### DIFF
--- a/pipeline/objects/graph.py
+++ b/pipeline/objects/graph.py
@@ -404,7 +404,7 @@ class Variable:
             max_length=self.max_length,
             choices=self.choices,
             dict_schema=self.dict_schema,
-            default=self.default,
+            default=self.default if hasattr(self, "default") else None,
         )
 
 


### PR DESCRIPTION
Apparently not all the old pipelines have a default value, so some migrated pipelines break in v4.