### PR TITLE
Plutopulp/handle raise for status

### DIFF
--- a/pipeline/cloud/asyncio/pipelines.py
+++ b/pipeline/cloud/asyncio/pipelines.py
@@ -23,7 +23,7 @@ async def run_pipeline(
     res = await http.async_post(
         "/v4/runs",
         json_data=run_create_schema.dict(),
-        raise_for_status=False,
+        handle_error=False,
     )
 
     if return_response:

--- a/pipeline/cloud/asyncio/pipelines.py
+++ b/pipeline/cloud/asyncio/pipelines.py
@@ -5,7 +5,6 @@ import httpx
 from pipeline.cloud import http
 from pipeline.cloud.pipelines import _data_to_run_input
 from pipeline.cloud.schemas.runs import Run, RunCreate, RunState
-from pipeline.util.logging import _print
 
 
 async def run_pipeline(
@@ -23,46 +22,11 @@ async def run_pipeline(
     res = await http.async_post(
         "/v4/runs",
         json_data=run_create_schema.dict(),
-        handle_error=False,
+        handle_error=not return_response,
     )
 
     if return_response:
         return res
-
-    if res.status_code == 500:
-        _print(
-            f"Failed run (status={res.status_code}, text={res.text}, "
-            f"headers={res.headers})",
-            level="ERROR",
-        )
-        raise Exception(f"Error: {res.status_code}, {res.text}", res.status_code)
-    elif res.status_code == 429:
-        _print(
-            f"Too many requests (status={res.status_code}, text={res.text})",
-            level="ERROR",
-        )
-        raise Exception(
-            "Too many requests, please try again later",
-            res.status_code,
-        )
-    elif res.status_code == 404:
-        _print(
-            f"Pipeline not found (status={res.status_code}, text={res.text})",
-            level="ERROR",
-        )
-        raise Exception("Pipeline not found", res.status_code)
-    elif res.status_code == 503:
-        _print(
-            f"Environment not cached (status={res.status_code}, text={res.text})",
-            level="ERROR",
-        )
-        raise Exception("Environment not cached", res.status_code)
-    elif res.status_code == 502:
-        _print(
-            "Gateway error",
-            level="ERROR",
-        )
-        raise Exception("Gateway error", res.status_code)
 
     run_get = Run.parse_obj(res.json())
 

--- a/pipeline/cloud/http.py
+++ b/pipeline/cloud/http.py
@@ -24,7 +24,7 @@ def get_response_error_dict(e: httpx.HTTPStatusError) -> t.Dict:
             detail = {"detail": detail}
     except (TypeError, KeyError):
         return {"message": "Something went wrong.", "response_json": e.response.json()}
-    return {**detail, "x-correlation-id": e.response.headers.get("x-correlation-id")}
+    return {**detail, "request_id": e.response.headers.get("x-correlation-id")}
 
 
 def handle_http_status_error(func):

--- a/pipeline/cloud/http.py
+++ b/pipeline/cloud/http.py
@@ -26,6 +26,7 @@ def get_response_error_dict(e: httpx.HTTPStatusError) -> t.Dict:
         return {"message": "Something went wrong.", "response_json": e.response.json()}
     return {**detail, "x-correlation-id": e.response.headers.get("x-correlation-id")}
 
+
 def handle_http_status_error(func):
     @functools.wraps(func)
     def wrapper(*args, **kwargs):

--- a/pipeline/cloud/http.py
+++ b/pipeline/cloud/http.py
@@ -31,7 +31,7 @@ def handle_http_status_error(func):
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
         response = func(*args, **kwargs)
-        if kwargs.pop("raise_for_status", True):
+        if kwargs.pop("handle_error", True):
             try:
                 response.raise_for_status()
             except httpx.HTTPStatusError as e:
@@ -93,25 +93,26 @@ def _get_async_client() -> httpx.AsyncClient:
 
 @handle_http_status_error
 def post(
-    endpoint: str, json_data: dict = None, raise_for_status: bool = True
+    endpoint: str,
+    json_data: dict = None,
+    handle_error: bool = True,
 ) -> httpx.Response:
     client = _get_client()
-    return client.post(endpoint, json=json_data)
+    response = client.post(endpoint, json=json_data)
+    return response
 
 
+@handle_http_status_error
 async def async_post(
     endpoint: str,
     json_data: dict = None,
-    raise_for_status: bool = True,
+    handle_error: bool = True,
 ) -> httpx.Response:
     client = _get_async_client()
     response = await client.post(
         endpoint,
         json=json_data,
     )
-    if raise_for_status:
-        response.raise_for_status()
-
     return response
 
 
@@ -119,7 +120,7 @@ async def async_post(
 def patch(
     endpoint: str,
     json_data: dict = None,
-    raise_for_status: bool = True,
+    handle_error: bool = True,
 ) -> httpx.Response:
     client = _get_client()
     return client.patch(
@@ -131,19 +132,23 @@ def patch(
 @handle_http_status_error
 def get(
     endpoint: str,
+    handle_error: bool = True,
     **kwargs,
 ) -> httpx.Response:
     client = _get_client()
-    return client.get(endpoint, **kwargs)
+    response = client.get(endpoint, **kwargs)
+    return response
 
 
 @handle_http_status_error
 def delete(
     endpoint: str,
+    handle_error: bool = True,
     **kwargs,
 ) -> httpx.Response:
     client = _get_client()
-    return client.delete(endpoint, **kwargs)
+    response = client.delete(endpoint, **kwargs)
+    return response
 
 
 def create_callback(encoder: MultipartEncoder) -> t.Callable:

--- a/pipeline/cloud/http.py
+++ b/pipeline/cloud/http.py
@@ -20,10 +20,11 @@ _client_async = None
 def get_response_error_dict(e: httpx.HTTPStatusError) -> t.Dict:
     try:
         detail = e.response.json()["detail"]
+        if not isinstance(detail, dict):
+            detail = {"detail": detail}
     except (TypeError, KeyError):
         return {"message": "Something went wrong.", "response_json": e.response.json()}
     return {**detail, "x-correlation-id": e.response.headers.get("x-correlation-id")}
-
 
 def handle_http_status_error(func):
     @functools.wraps(func)

--- a/pipeline/cloud/logs.py
+++ b/pipeline/cloud/logs.py
@@ -2,7 +2,6 @@ import json
 import urllib.parse
 from typing import Generator
 
-from httpx import HTTPStatusError
 from websockets.exceptions import ConnectionClosedError, ConnectionClosedOK
 from websockets.sync.client import connect
 

--- a/pipeline/cloud/logs.py
+++ b/pipeline/cloud/logs.py
@@ -12,15 +12,9 @@ from pipeline.util.logging import _print
 
 
 def get_run_logs(run_id: str) -> list[str] | None:
-    try:
-        response = http.get(
-            f"/v4/logs/run/{run_id}",
-        )
-    except HTTPStatusError as e:
-        print(
-            f"Error getting run logs: {e.response.status_code} - {e.response.content}"
-        )
-        return
+    response = http.get(
+        f"/v4/logs/run/{run_id}",
+    )
     response_json = response.json()
     return response_json.get("log_entries")
 

--- a/pipeline/cloud/pipelines.py
+++ b/pipeline/cloud/pipelines.py
@@ -80,36 +80,6 @@ def _run_pipeline(run_create_schema: RunCreate):
         handle_error=True,
     )
 
-    if res.status_code == 500:
-        _print(
-            f"Failed run (status={res.status_code}, text={res.text}, "
-            f"headers={res.headers})",
-            level="ERROR",
-        )
-        raise Exception(f"Error: {res.status_code}, {res.text}", res.status_code)
-    elif res.status_code == 429:
-        _print(
-            f"Too many requests (status={res.status_code}, text={res.text})",
-            level="ERROR",
-        )
-        raise Exception(
-            "Too many requests, please try again later",
-            res.status_code,
-        )
-    elif res.status_code == 404:
-        _print(
-            f"Pipeline not found (status={res.status_code}, text={res.text})",
-            level="ERROR",
-        )
-        raise Exception("Pipeline not found", res.status_code)
-
-    elif res.status_code == 502:
-        _print(
-            "Gateway error",
-            level="ERROR",
-        )
-        raise Exception("Gateway error", res.status_code)
-
     return ClusterRunResult.parse_raw(res.text)
 
 

--- a/pipeline/cloud/pipelines.py
+++ b/pipeline/cloud/pipelines.py
@@ -77,7 +77,7 @@ def _run_pipeline(run_create_schema: RunCreate):
     res = http.post(
         "/v4/runs",
         json_data=run_create_schema.dict(),
-        handle_error=False,
+        handle_error=True,
     )
 
     if res.status_code == 500:
@@ -102,12 +102,7 @@ def _run_pipeline(run_create_schema: RunCreate):
             level="ERROR",
         )
         raise Exception("Pipeline not found", res.status_code)
-    elif res.status_code == 503:
-        _print(
-            f"Environment not cached (status={res.status_code}, text={res.text})",
-            level="ERROR",
-        )
-        raise Exception("Environment not cached", res.status_code)
+
     elif res.status_code == 502:
         _print(
             "Gateway error",

--- a/pipeline/cloud/pipelines.py
+++ b/pipeline/cloud/pipelines.py
@@ -77,7 +77,7 @@ def _run_pipeline(run_create_schema: RunCreate):
     res = http.post(
         "/v4/runs",
         json_data=run_create_schema.dict(),
-        raise_for_status=False,
+        handle_error=False,
     )
 
     if res.status_code == 500:

--- a/pipeline/cloud/pipelines.py
+++ b/pipeline/cloud/pipelines.py
@@ -5,7 +5,6 @@ from pipeline.cloud.files import resolve_run_input_file_object
 from pipeline.cloud.schemas.runs import ClusterRunResult, RunCreate, RunInput, RunIOType
 from pipeline.objects import File
 from pipeline.objects.graph import InputSchema
-from pipeline.util.logging import _print
 
 
 class PipelineRunError(Exception):

--- a/pipeline/cloud/pointers.py
+++ b/pipeline/cloud/pointers.py
@@ -11,14 +11,16 @@ def create_pointer(
     locked: bool = False,
 ) -> None:
     try:
-        http.post(
+        response = http.post(
             "/v3/pointers",
             json_data=pointer_schemas.PointerCreate(
                 pointer=pointer,
                 pointer_or_pipeline_id=target_pipeline_id_or_pointer,
                 locked=locked,
             ).dict(),
+            handle_error=False,
         )
+        response.raise_for_status()
     except HTTPStatusError as e:
         if e.response.status_code == 409 and overwrite:
             http.patch(

--- a/pipeline/console/container/__init__.py
+++ b/pipeline/console/container/__init__.py
@@ -302,18 +302,13 @@ def _push_container(namespace: Namespace):
 
     upload_token = None
     if registry_info.special_auth:
-        try:
-            start_upload_response = http.post(
-                endpoint="/v4/registry/start-upload",
-                json_data={
-                    "pipeline_name": pipeline_name,
-                    "pipeline_tag": None,
-                },
-            )
-        except httpx.HTTPStatusError as e:
-            msg = e.response.json()
-            print("Error received from API: " + msg["detail"]["message"])
-            return
+        start_upload_response = http.post(
+            endpoint="/v4/registry/start-upload",
+            json_data={
+                "pipeline_name": pipeline_name,
+                "pipeline_tag": None,
+            },
+        )
         start_upload_dict = start_upload_response.json()
         upload_token = start_upload_dict.get("bearer", None)
 

--- a/pipeline/console/container/__init__.py
+++ b/pipeline/console/container/__init__.py
@@ -6,7 +6,6 @@ from argparse import Namespace
 from pathlib import Path
 
 import docker
-import httpx
 import yaml
 from docker.types import DeviceRequest, LogConfig
 from pydantic import BaseModel

--- a/pipeline/console/targets/pipelines.py
+++ b/pipeline/console/targets/pipelines.py
@@ -176,7 +176,7 @@ def _edit_pipeline(args: Namespace) -> None:
         return
 
     http.patch(
-        f"/v3/pipelines/{pipeline_id}",
+        f"/v4/pipelines/{pipeline_id}",
         patch_schema.dict(),
     )
 


### PR DESCRIPTION
In this PR we add a decorator for our API client request methods which handles catching all http status errors from the server and displaying them to the user. We also show the correlation-id of the request, which users can provide to the Mystic team for debugging purposes. Errors/Exceptions should no longer be handled on this client but instead directly on the server, and simply displayed to the user on the client.