### PR TITLE
Quick logging fix

### DIFF
--- a/pipeline/container/logging.py
+++ b/pipeline/container/logging.py
@@ -12,7 +12,7 @@ from loguru import logger
 class StreamToLogger:
     def __init__(self, level="INFO"):
         self._level = level
-        self.encoding = 'utf'
+        self.encoding = 'utf-8'
 
     def write(self, buffer):
         for line in buffer.rstrip().splitlines():

--- a/pipeline/container/logging.py
+++ b/pipeline/container/logging.py
@@ -12,6 +12,7 @@ from loguru import logger
 class StreamToLogger:
     def __init__(self, level="INFO"):
         self._level = level
+        self.encoding = 'utf'
 
     def write(self, buffer):
         for line in buffer.rstrip().splitlines():

--- a/pipeline/container/logging.py
+++ b/pipeline/container/logging.py
@@ -12,7 +12,7 @@ from loguru import logger
 class StreamToLogger:
     def __init__(self, level="INFO"):
         self._level = level
-        self.encoding = 'utf-8'
+        self.encoding = "utf-8"
 
     def write(self, buffer):
         for line in buffer.rstrip().splitlines():


### PR DESCRIPTION
We were getting this error from a pipeline in V4:

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/site-packages/pipeline/container/manager.py", line 64, in startup
    self.pipeline._startup()
  File "/usr/local/lib/python3.10/site-packages/pipeline/objects/graph.py", line 617, in _startup
    node_function.function(node_function.class_instance, *function_inputs)
  File "/home/or/oscar/codellama/pipeline_codellama_13.py", line 37, in load_model
  File "/usr/local/lib/python3.10/site-packages/vllm/__init__.py", line 4, in <module>
    from vllm.engine.async_llm_engine import AsyncLLMEngine
  File "/usr/local/lib/python3.10/site-packages/vllm/engine/async_llm_engine.py", line 8, in <module>
    from vllm.engine.llm_engine import LLMEngine
  File "/usr/local/lib/python3.10/site-packages/vllm/engine/llm_engine.py", line 10, in <module>
    from vllm.engine.ray_utils import RayWorker, initialize_cluster, ray
  File "/usr/local/lib/python3.10/site-packages/vllm/engine/ray_utils.py", line 8, in <module>
    from ray.air.util.torch_dist import TorchDistributedWorker
  File "/usr/local/lib/python3.10/site-packages/ray/air/util/torch_dist.py", line 18, in <module>
    from ray.train._internal.utils import get_address_and_port
  File "/usr/local/lib/python3.10/site-packages/ray/train/__init__.py", line 3, in <module>
    from ray.train._internal.data_config import DataConfig
  File "/usr/local/lib/python3.10/site-packages/ray/train/_internal/data_config.py", line 4, in <module>
    from ray.train.constants import TRAIN_DATASET_KEY
  File "/usr/local/lib/python3.10/site-packages/ray/train/constants.py", line 5, in <module>
    from ray import tune  # noqa: F401
  File "/usr/local/lib/python3.10/site-packages/ray/tune/__init__.py", line 2, in <module>
    from ray.tune.tune import run_experiments, run
  File "/usr/local/lib/python3.10/site-packages/ray/tune/tune.py", line 36, in <module>
    from ray.tune.experimental.output import (
  File "/usr/local/lib/python3.10/site-packages/ray/tune/experimental/output.py", line 521, in <module>
    if sys.stdout and sys.stdout.encoding and sys.stdout.encoding.startswith("utf"):
AttributeError: 'StreamToLogger' object has no attribute 'encoding'

  Pipeline failed to load       
```

So add the encoding attribute manually to the StreamToLogger object.

This works now: https://beta.v4.mystic.ai/meta/codellama-13b-instruct/play