### PR TITLE
pipeline docker image tweak

### DIFF
--- a/pipeline/cloud/schemas/pipelines.py
+++ b/pipeline/cloud/schemas/pipelines.py
@@ -37,6 +37,8 @@ class PipelineStartUpload(BaseModel):
 class PipelineStartUploadResponse(BaseModel):
     bearer: str
     upload_registry: t.Optional[str]
+    #: Full username/pipeline_name. Used for naming docker image
+    pipeline_name: str
 
 
 class PipelineCreate(BaseModel):

--- a/pipeline/console/container/__init__.py
+++ b/pipeline/console/container/__init__.py
@@ -317,7 +317,8 @@ def _push_container(namespace: Namespace):
             raise ValueError("No upload token found")
         if true_pipeline_name is None:
             # will fail unless they use their correct username in the pipeline name
-            # just makes this deployment of pipeline backwards compatible with older catalyst
+            # just makes this deployment of pipeline backwards compatible 
+            # with older catalyst
             true_pipeline_name = pipeline_name
 
         # Login to upload registry
@@ -334,7 +335,8 @@ def _push_container(namespace: Namespace):
     _print(f"Pushing image to upload registry {upload_registry}", "INFO")
 
     docker_client.images.get(pipeline_name).tag(image_to_push_reg)
-    # Do this after tagging, because we need to use the old pipeline name to tag the local image
+    # Do this after tagging, because we need to use 
+    # the old pipeline name to tag the local image
     if true_pipeline_name:
         pipeline_name = true_pipeline_name
 

--- a/pipeline/console/container/__init__.py
+++ b/pipeline/console/container/__init__.py
@@ -317,7 +317,7 @@ def _push_container(namespace: Namespace):
             raise ValueError("No upload token found")
         if true_pipeline_name is None:
             # will fail unless they use their correct username in the pipeline name
-            # just makes this deployment of pipeline backwards compatible 
+            # just makes this deployment of pipeline backwards compatible
             # with older catalyst
             true_pipeline_name = pipeline_name
 
@@ -335,7 +335,7 @@ def _push_container(namespace: Namespace):
     _print(f"Pushing image to upload registry {upload_registry}", "INFO")
 
     docker_client.images.get(pipeline_name).tag(image_to_push_reg)
-    # Do this after tagging, because we need to use 
+    # Do this after tagging, because we need to use
     # the old pipeline name to tag the local image
     if true_pipeline_name:
         pipeline_name = true_pipeline_name

--- a/pipeline/console/container/__init__.py
+++ b/pipeline/console/container/__init__.py
@@ -315,11 +315,6 @@ def _push_container(namespace: Namespace):
 
         if upload_token is None:
             raise ValueError("No upload token found")
-        if true_pipeline_name is None:
-            # will fail unless they use their correct username in the pipeline name
-            # just makes this deployment of pipeline backwards compatible
-            # with older catalyst
-            true_pipeline_name = pipeline_name
 
         # Login to upload registry
         docker_client.login(

--- a/pipeline/console/container/__init__.py
+++ b/pipeline/console/container/__init__.py
@@ -316,7 +316,9 @@ def _push_container(namespace: Namespace):
         if upload_token is None:
             raise ValueError("No upload token found")
         if true_pipeline_name is None:
-            raise ValueError("No authed pipeline name found")
+            # will fail unless they use their correct username in the pipeline name
+            # just makes this deployment of pipeline backwards compatible with older catalyst
+            true_pipeline_name = pipeline_name
 
         # Login to upload registry
         docker_client.login(


### PR DESCRIPTION
This allows catalyst users to defining their pipeline image without having to prepend by username.
Basically creates a new image name from the response from the API resolved with username, and pushes that to the registry.