### PR TITLE
Don't use base url param

### DIFF
--- a/pipeline/console/container/__init__.py
+++ b/pipeline/console/container/__init__.py
@@ -202,7 +202,7 @@ def _build_container(namespace: Namespace):
 
     dockerfile_path = Path("./pipeline.dockerfile")
     dockerfile_path.write_text(dockerfile_str)
-    docker_client = docker.APIClient(base_url="unix://var/run/docker.sock")
+    docker_client = docker.APIClient()
     generator = docker_client.build(
         # fileobj=dockerfile_path.open("rb"),
         path="./",


### PR DESCRIPTION
By default the docker client does a lot to work out how to connect, we ruin that by using a hardcoded address.

This seems to not break Mac. Worked for our windows customer as well.