### PR TITLE
Allow input exceptions to show in run outputs

### DIFF
--- a/examples/run_example.py
+++ b/examples/run_example.py
@@ -4,14 +4,13 @@ from pipeline.cloud.pipelines import run_pipeline
 
 start_time = datetime.datetime.now()
 
-pointer = "betauser/simple:v1"
+pointer = "test:v1"
 
-result = run_pipeline(pointer, "a")
+result = run_pipeline(pointer, 1)
 
 end_time = datetime.datetime.now()
 
 total_time = (end_time - start_time).total_seconds()
 
-print(result.id)
 print(f"Total time taken: {total_time}, result: {result.outputs_formatted()}")
-print(f"Total time taken: {total_time}, result: {result.error}")
+print(f"Error: {result.error}")

--- a/examples/run_example.py
+++ b/examples/run_example.py
@@ -4,12 +4,14 @@ from pipeline.cloud.pipelines import run_pipeline
 
 start_time = datetime.datetime.now()
 
-pointer = "test:v1"
+pointer = "betauser/simple:v1"
 
-result = run_pipeline(pointer, 1)
+result = run_pipeline(pointer, "a")
 
 end_time = datetime.datetime.now()
 
 total_time = (end_time - start_time).total_seconds()
 
+print(result.id)
 print(f"Total time taken: {total_time}, result: {result.outputs_formatted()}")
+print(f"Total time taken: {total_time}, result: {result.error}")

--- a/examples/run_example.py
+++ b/examples/run_example.py
@@ -12,5 +12,11 @@ end_time = datetime.datetime.now()
 
 total_time = (end_time - start_time).total_seconds()
 
-print(f"Total time taken: {total_time}, result: {result.outputs_formatted()}")
-print(f"Error: {result.error}")
+if result.error:
+    print(f"Error: {result.error.json()}")
+else:
+    print(
+        f"Total time taken: {total_time}\n"
+        f"Run ID: {result.id}\n"
+        f"Result: {result.outputs_formatted()}"
+    )

--- a/pipeline/container/manager.py
+++ b/pipeline/container/manager.py
@@ -219,8 +219,8 @@ class Manager:
     ) -> t.Any:
         with logger.contextualize(run_id=run_id):
             logger.info("Running pipeline")
+            args = self._parse_inputs(input_data, self.pipeline)
             try:
-                args = self._parse_inputs(input_data, self.pipeline)
                 result = self.pipeline.run(*args)
             except Exception as exc:
                 raise RunnableError(exception=exc, traceback=traceback.format_exc())

--- a/pipeline/container/manager.py
+++ b/pipeline/container/manager.py
@@ -13,7 +13,7 @@ from loguru import logger
 
 from pipeline.cloud.schemas import pipelines as pipeline_schemas
 from pipeline.cloud.schemas import runs as run_schemas
-from pipeline.exceptions import RunnableError
+from pipeline.exceptions import RunInputException, RunnableError
 from pipeline.objects import Directory, File, Graph
 from pipeline.objects.graph import InputSchema
 
@@ -155,7 +155,7 @@ class Manager:
                 input_schema = run_schemas.RunInput.parse_obj(item)
                 if input_schema.type == run_schemas.RunIOType.file:
                     if input_schema.file_path is None and input_schema.file_url is None:
-                        raise Exception(
+                        raise RunInputException(
                             "A file must either have a path or url attribute"
                         )
                     path_or_url = (
@@ -164,7 +164,7 @@ class Manager:
                         else input_schema.file_path
                     )
                     if path_or_url is None:
-                        raise Exception(
+                        raise RunInputException(
                             "A file must either have a path or url attribute"
                         )
 
@@ -178,7 +178,7 @@ class Manager:
         graph_inputs = list(filter(lambda v: v.is_input, graph.variables))
 
         if len(inputs) != len(graph_inputs):
-            raise Exception("Inputs do not match graph inputs")
+            raise RunInputException("Inputs do not match graph inputs")
 
         final_inputs = []
 
@@ -191,11 +191,11 @@ class Manager:
                     if isinstance(value, UnionType) or "typing.Optional" in str(value):
                         var_union_types = list(t.get_args(value))
                         if len(var_union_types) > 2:
-                            raise Exception("Only support Union of 2 types")
+                            raise RunInputException("Only support Union of 2 types")
                         if NoneType in var_union_types:
                             var_union_types.remove(NoneType)
                         else:
-                            raise Exception("Only support Union with None")
+                            raise RunInputException("Only support Union with None")
                         var_type = var_union_types[0]
                     else:
                         var_type = value
@@ -219,8 +219,8 @@ class Manager:
     ) -> t.Any:
         with logger.contextualize(run_id=run_id):
             logger.info("Running pipeline")
-            args = self._parse_inputs(input_data, self.pipeline)
             try:
+                args = self._parse_inputs(input_data, self.pipeline)
                 result = self.pipeline.run(*args)
             except Exception as exc:
                 raise RunnableError(exception=exc, traceback=traceback.format_exc())

--- a/pipeline/objects/graph.py
+++ b/pipeline/objects/graph.py
@@ -656,7 +656,7 @@ class Graph:
                     input = float(input)
                 else:
                     raise RunInputException(
-                        "Input type mismatch, expceted %s got %s"
+                        "Input type mismatch, expected %s got %s"
                         % (
                             input_variables[i].type_class,
                             input.__class__,


### PR DESCRIPTION
For now include run input exceptions in a run's errors. Previously this error would get swallowed and be invisible to the user.