### PR TITLE
Handle JSONDecodeError in get_response_error_dict()

### DIFF
--- a/pipeline/cloud/http.py
+++ b/pipeline/cloud/http.py
@@ -12,6 +12,7 @@ from tqdm import tqdm
 
 from pipeline import current_configuration
 from pipeline.util.logging import PIPELINE_STR, _print
+from json.decoder import JSONDecodeError
 
 _client = None
 _client_async = None
@@ -22,6 +23,8 @@ def get_response_error_dict(e: httpx.HTTPStatusError) -> t.Dict:
         detail = e.response.json()["detail"]
         if not isinstance(detail, dict):
             detail = {"detail": detail}
+    except JSONDecodeError:
+        return {"message": "Something went wrong.", "response": e.response}
     except (TypeError, KeyError):
         return {"message": "Something went wrong.", "response_json": e.response.json()}
     return {**detail, "request_id": e.response.headers.get("x-correlation-id")}


### PR DESCRIPTION
# Pull request outline

If any endpoint returns 502, the error message looks like a dog's breakfast and doesn't actually say 502 anywhere:

```
Expecting value: line 2 column 1 (char 1)
Traceback (most recent call last):
  File "/home/user/.local/lib/python3.10/site-packages/pipeline/console/__init__.py", line 64, in _run
    execute_cli(parser)
  File "/home/user/.local/lib/python3.10/site-packages/pipeline/console/__init__.py", line 54, in execute_cli
    selected_func(parsed_args)
  File "/home/user/.local/lib/python3.10/site-packages/pipeline/console/container/__init__.py", line 291, in _push_container
    registry_info = http.get(endpoint="/v4/registry")
  File "/home/user/.local/lib/python3.10/site-packages/pipeline/cloud/http.py", line 40, in wrapper
    get_response_error_dict(e),
  File "/home/user/.local/lib/python3.10/site-packages/pipeline/cloud/http.py", line 27, in get_response_error_dict
    return {"message": "Something went wrong.", "response_json": e.response.json()}
  File "/home/user/.local/lib/python3.10/site-packages/httpx/_models.py", line 762, in json
    return jsonlib.loads(self.content, **kwargs)
  File "/usr/lib/python3.10/json/__init__.py", line 346, in loads
    return _default_decoder.decode(s)
  File "/usr/lib/python3.10/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/lib/python3.10/json/decoder.py", line 355, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 2 column 1 (char 1)
```

After this PR, the JSONDecoderError is caught and handled correctly:

```
Pipeline 15:19:21 - [ERROR]: {'message': 'Something went wrong.', 'response': <Response [502 Bad Gateway]>}
Traceback (most recent call last):
  File "/home/user/.local/lib/python3.10/site-packages/pipeline/console/__init__.py", line 64, in _run
    execute_cli(parser)
  File "/home/user/.local/lib/python3.10/site-packages/pipeline/console/__init__.py", line 54, in execute_cli
    selected_func(parsed_args)
  File "/home/user/.local/lib/python3.10/site-packages/pipeline/console/container/__init__.py", line 290, in _push_container
    registry_info = http.get(endpoint="/v4/registry")
  File "/home/user/.local/lib/python3.10/site-packages/pipeline/cloud/http.py", line 39, in wrapper
    response.raise_for_status()
  File "/home/user/.local/lib/python3.10/site-packages/httpx/_models.py", line 759, in raise_for_status
    raise HTTPStatusError(message, request=request, response=self)
httpx.HTTPStatusError: Server error '502 Bad Gateway' for url 'https://mystic.ai/v4/registry'
For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/502
```



## Checklist:
- [ ] Docs updated
- [ ] Tests written
- [ ] Check for breaking changes in Resource
- [ ] Version bumped

Added:
- None

Changed:
- cloud.http.get_response_error_dict()

Removed:
- None

## Related issues:
_none_

___

- _You can add a reference to an issue using hash followed by the issue number_
- _If a checklist item is to be ignored it must be struck through_
