### PR TITLE
Improve error handling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pipeline-ai"
-version = "2.0.3"
+version = "2.0.4"
 description = "Pipelines for machine learning workloads."
 authors = [
   "Paul Hetherington <ph@mystic.ai>",


### PR DESCRIPTION
# Pull request outline

Currently when there are no resources available the error message we return is a bit verbose and could be a bit worrying for users (the default error message from httpx tells users to go to https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/503 for more info, which is a bit confusing).

This PR introduces 2 custom exceptions, `APIError` for general HTTP errors and `NoResourcesAvailable` for when a pipeline has not scaled up. This makes the error messaging nicer and also allows the user to use these exceptions in their own code.


## Checklist:
- [x] Version bumped
