### PR TITLE
Improve error handling in Pipeline

### DIFF
--- a/pipeline/cloud/schemas/pipelines.py
+++ b/pipeline/cloud/schemas/pipelines.py
@@ -117,6 +117,7 @@ class PipelineListPagination(pagination.Pagination):
     order_by: OrderBy
     order: pagination.Order
 
+
 class PipelineDeploymentStatus(str, Enum):
     not_deployed = "not_deployed"
     deploying = "deploying"

--- a/pipeline/cloud/schemas/pipelines.py
+++ b/pipeline/cloud/schemas/pipelines.py
@@ -88,14 +88,6 @@ class PipelineGet(Pipeline):
     extras: t.Optional[dict]
 
 
-class PipelineDeploymentStatus(str, Enum):
-    not_deployed = "not_deployed"
-    deploying = "deploying"
-    deployed = "deployed"
-    failed = "failed"
-    deleting = "deleting"
-    deleted = "deleted"
-
 class PipelinePatch(BaseModel):
     input_variables: t.Optional[t.List[IOVariable]]
     output_variables: t.Optional[t.List[IOVariable]]
@@ -108,8 +100,13 @@ class PipelinePatch(BaseModel):
 
     extras: t.Optional[dict]
 
-    deployment_status: t.Optional[PipelineDeploymentStatus]
-
+class PipelineDeploymentStatus(str, Enum):
+    not_deployed = "not_deployed"
+    deploying = "deploying"
+    deployed = "deployed"
+    failed = "failed"
+    deleting = "deleting"
+    deleted = "deleted"
 
 class PipelineListPagination(pagination.Pagination):
     class OrderBy(str, Enum):

--- a/pipeline/cloud/schemas/pipelines.py
+++ b/pipeline/cloud/schemas/pipelines.py
@@ -134,6 +134,9 @@ class PipelineState(str, Enum):
     load_failed = "load_failed"
     startup_failed = "startup_failed"
 
+    # backwards compatability
+    failed = "failed"
+
 
 class PipelineContainerState(BaseModel):
     state: PipelineState

--- a/pipeline/cloud/schemas/pipelines.py
+++ b/pipeline/cloud/schemas/pipelines.py
@@ -132,8 +132,7 @@ class PipelineState(str, Enum):
     loading = "loading"
     loaded = "loaded"
     load_failed = "load_failed"
-    # This is really startup_failed
-    failed = "failed"
+    startup_failed = "startup_failed"
 
 
 class PipelineContainerState(BaseModel):

--- a/pipeline/cloud/schemas/pipelines.py
+++ b/pipeline/cloud/schemas/pipelines.py
@@ -100,13 +100,6 @@ class PipelinePatch(BaseModel):
 
     extras: t.Optional[dict]
 
-class PipelineDeploymentStatus(str, Enum):
-    not_deployed = "not_deployed"
-    deploying = "deploying"
-    deployed = "deployed"
-    failed = "failed"
-    deleting = "deleting"
-    deleted = "deleted"
 
 class PipelineListPagination(pagination.Pagination):
     class OrderBy(str, Enum):
@@ -124,6 +117,13 @@ class PipelineListPagination(pagination.Pagination):
     order_by: OrderBy
     order: pagination.Order
 
+class PipelineDeploymentStatus(str, Enum):
+    not_deployed = "not_deployed"
+    deploying = "deploying"
+    deployed = "deployed"
+    failed = "failed"
+    deleting = "deleting"
+    deleted = "deleted"
 
 
 class PipelineState(str, Enum):

--- a/pipeline/cloud/schemas/pipelines.py
+++ b/pipeline/cloud/schemas/pipelines.py
@@ -133,6 +133,8 @@ class PipelineState(str, Enum):
     not_loaded = "not_loaded"
     loading = "loading"
     loaded = "loaded"
+    load_failed = "load_failed"
+    # This is really startup_failed
     failed = "failed"
 
 

--- a/pipeline/cloud/schemas/pipelines.py
+++ b/pipeline/cloud/schemas/pipelines.py
@@ -88,6 +88,14 @@ class PipelineGet(Pipeline):
     extras: t.Optional[dict]
 
 
+class PipelineDeploymentStatus(str, Enum):
+    not_deployed = "not_deployed"
+    deploying = "deploying"
+    deployed = "deployed"
+    failed = "failed"
+    deleting = "deleting"
+    deleted = "deleted"
+
 class PipelinePatch(BaseModel):
     input_variables: t.Optional[t.List[IOVariable]]
     output_variables: t.Optional[t.List[IOVariable]]
@@ -99,6 +107,8 @@ class PipelinePatch(BaseModel):
     accelerators: t.Optional[t.List[Accelerator]]
 
     extras: t.Optional[dict]
+
+    deployment_status: t.Optional[PipelineDeploymentStatus]
 
 
 class PipelineListPagination(pagination.Pagination):
@@ -117,14 +127,6 @@ class PipelineListPagination(pagination.Pagination):
     order_by: OrderBy
     order: pagination.Order
 
-
-class PipelineDeploymentStatus(str, Enum):
-    not_deployed = "not_deployed"
-    deploying = "deploying"
-    deployed = "deployed"
-    failed = "failed"
-    deleting = "deleting"
-    deleted = "deleted"
 
 
 class PipelineState(str, Enum):

--- a/pipeline/cloud/schemas/runs.py
+++ b/pipeline/cloud/schemas/runs.py
@@ -216,6 +216,7 @@ class ContainerRunErrorType(str, Enum):
     pipeline_error = "pipeline_error"
     startup_error = "startup_error"
     pipeline_loading = "pipeline_loading"
+    load_error = "load_error"
     unknown = "unknown"
 
 

--- a/pipeline/cloud/schemas/runs.py
+++ b/pipeline/cloud/schemas/runs.py
@@ -216,7 +216,6 @@ class ContainerRunErrorType(str, Enum):
     pipeline_error = "pipeline_error"
     startup_error = "startup_error"
     pipeline_loading = "pipeline_loading"
-    load_error = "load_error"
     unknown = "unknown"
 
 

--- a/pipeline/container/manager.py
+++ b/pipeline/container/manager.py
@@ -44,6 +44,7 @@ class Manager:
         self.pipeline_path = pipeline_path
         self.pipeline_module_str, self.pipeline_name_str = pipeline_path.split(":")
 
+        self.pipeline_state = pipeline_schemas.PipelineState.loading
         try:
             self.pipeline_module = importlib.import_module(self.pipeline_module_str)
             self.pipeline: Graph = getattr(self.pipeline_module, self.pipeline_name_str)
@@ -82,7 +83,6 @@ class Manager:
         # add context to enable fetching of startup logs
         with logger.contextualize(pipeline_stage="startup"):
             logger.info("Starting pipeline")
-            self.pipeline_state = pipeline_schemas.PipelineState.loading
             try:
                 self.pipeline._startup()
             except Exception:

--- a/pipeline/container/manager.py
+++ b/pipeline/container/manager.py
@@ -54,9 +54,13 @@ class Manager:
             self.pipeline: Graph = getattr(self.pipeline_module, self.pipeline_name_str)
         except ModuleNotFoundError:
             self.pipeline_state = pipeline_schemas.PipelineState.load_failed
+            tb = traceback.format_exc()
+            self.pipeline_state_message = tb
             raise ValueError(f"Could not find module {self.pipeline_module_str}")
         except AttributeError:
             self.pipeline_state = pipeline_schemas.PipelineState.load_failed
+            tb = traceback.format_exc()
+            self.pipeline_state_message = tb
             raise ValueError(
                 (
                     f"Could not find pipeline {self.pipeline_name_str} in module"
@@ -65,6 +69,8 @@ class Manager:
             )
         except Exception as e:
             self.pipeline_state = pipeline_schemas.PipelineState.load_failed
+            tb = traceback.format_exc()
+            self.pipeline_state_message = tb
             raise ValueError(f"Unexpected error: {e}")
 
         self.pipeline_name = os.environ.get("PIPELINE_NAME", "unknown")

--- a/pipeline/container/manager.py
+++ b/pipeline/container/manager.py
@@ -53,8 +53,10 @@ class Manager:
             self.pipeline_module = importlib.import_module(self.pipeline_module_str)
             self.pipeline: Graph = getattr(self.pipeline_module, self.pipeline_name_str)
         except ModuleNotFoundError:
+            self.pipeline_state = pipeline_schemas.PipelineState.load_failed
             raise ValueError(f"Could not find module {self.pipeline_module_str}")
         except AttributeError:
+            self.pipeline_state = pipeline_schemas.PipelineState.load_failed
             raise ValueError(
                 (
                     f"Could not find pipeline {self.pipeline_name_str} in module"
@@ -62,6 +64,7 @@ class Manager:
                 )
             )
         except Exception as e:
+            self.pipeline_state = pipeline_schemas.PipelineState.load_failed
             raise ValueError(f"Unexpected error: {e}")
 
         self.pipeline_name = os.environ.get("PIPELINE_NAME", "unknown")

--- a/pipeline/container/manager.py
+++ b/pipeline/container/manager.py
@@ -75,7 +75,6 @@ class Manager:
             tb = traceback.format_exc()
             self.pipeline_state_message = tb
             return
-        
 
     def startup(self):
         if self.pipeline_state == pipeline_schemas.PipelineState.load_failed:

--- a/pipeline/container/manager.py
+++ b/pipeline/container/manager.py
@@ -88,7 +88,7 @@ class Manager:
             except Exception:
                 tb = traceback.format_exc()
                 logger.exception("Exception raised during pipeline execution")
-                self.pipeline_state = pipeline_schemas.PipelineState.failed
+                self.pipeline_state = pipeline_schemas.PipelineState.startup_failed
                 self.pipeline_state_message = tb
             else:
                 self.pipeline_state = pipeline_schemas.PipelineState.loaded

--- a/pipeline/container/manager.py
+++ b/pipeline/container/manager.py
@@ -32,43 +32,49 @@ def _get_url_or_path(input_schema: run_schemas.RunInput) -> str | None:
 
 class Manager:
     def _load(self, pipeline_path: str):
-        if ":" not in pipeline_path:
-            raise ValueError(
-                "Invalid pipeline path, must be in format <module_or_file>:<pipeline>"
-            )
-        if len(pipeline_path.split(":")) != 2:
-            raise ValueError(
-                "Invalid pipeline path, must be in format <module_or_file>:<pipeline>"
-            )
+        with logger.contextualize(pipeline_stage="loading"):
+            logger.info("Loading pipeline")
 
-        self.pipeline_path = pipeline_path
-        self.pipeline_module_str, self.pipeline_name_str = pipeline_path.split(":")
-
-        self.pipeline_state = pipeline_schemas.PipelineState.loading
-        try:
-            self.pipeline_module = importlib.import_module(self.pipeline_module_str)
-            self.pipeline: Graph = getattr(self.pipeline_module, self.pipeline_name_str)
-        except ModuleNotFoundError:
-            raise ValueError(f"Could not find module {self.pipeline_module_str}")
-        except AttributeError:
-            raise ValueError(
-                (
-                    f"Could not find pipeline {self.pipeline_name_str} in module"
-                    f" {self.pipeline_module_str}"
+            if ":" not in pipeline_path:
+                raise ValueError(
+                    "Invalid pipeline path, "
+                    + "must be in format <module_or_file>:<pipeline>"
                 )
-            )
+            if len(pipeline_path.split(":")) != 2:
+                raise ValueError(
+                    "Invalid pipeline path, "
+                    + "must be in format <module_or_file>:<pipeline>"
+                )
 
-        self.pipeline_name = os.environ.get("PIPELINE_NAME", "unknown")
-        self.pipeline_image = os.environ.get("PIPELINE_IMAGE", "unknown")
+            self.pipeline_path = pipeline_path
+            self.pipeline_module_str, self.pipeline_name_str = pipeline_path.split(":")
 
-        logger.info(f"Pipeline set to {self.pipeline_path}")
+            self.pipeline_state = pipeline_schemas.PipelineState.loading
+            try:
+                self.pipeline_module = importlib.import_module(self.pipeline_module_str)
+                self.pipeline: Graph = getattr(
+                    self.pipeline_module, self.pipeline_name_str
+                )
+            except ModuleNotFoundError:
+                raise ValueError(f"Could not find module {self.pipeline_module_str}")
+            except AttributeError:
+                raise ValueError(
+                    (
+                        f"Could not find pipeline {self.pipeline_name_str} in module"
+                        f" {self.pipeline_module_str}"
+                    )
+                )
+
+            self.pipeline_name = os.environ.get("PIPELINE_NAME", "unknown")
+            self.pipeline_image = os.environ.get("PIPELINE_IMAGE", "unknown")
+
+            logger.info(f"Pipeline set to {self.pipeline_path}")
 
     def __init__(self, pipeline_path: str):
         self.pipeline_state: pipeline_schemas.PipelineState = (
             pipeline_schemas.PipelineState.not_loaded
         )
         self.pipeline_state_message: str | None = None
-
         try:
             self._load(pipeline_path)
         except Exception:

--- a/pipeline/container/routes/v4/container.py
+++ b/pipeline/container/routes/v4/container.py
@@ -33,7 +33,7 @@ async def is_ready(request: Request, response: Response):
     ]:
         response.status_code = 503
     elif run_manager.pipeline_state in [
-        pipeline_schemas.PipelineState.failed,
+        pipeline_schemas.PipelineState.startup_failed,
         pipeline_schemas.PipelineState.load_failed,
     ]:
         response.status_code = 500

--- a/pipeline/container/routes/v4/container.py
+++ b/pipeline/container/routes/v4/container.py
@@ -32,7 +32,10 @@ async def is_ready(request: Request, response: Response):
         pipeline_schemas.PipelineState.not_loaded,
     ]:
         response.status_code = 503
-    elif run_manager.pipeline_state == pipeline_schemas.PipelineState.failed:
+    elif run_manager.pipeline_state in [
+        pipeline_schemas.PipelineState.failed,
+        pipeline_schemas.PipelineState.load_failed,
+    ]:
         response.status_code = 500
 
     return pipeline_schemas.PipelineContainerState(

--- a/pipeline/container/routes/v4/container.py
+++ b/pipeline/container/routes/v4/container.py
@@ -51,8 +51,12 @@ async def is_ready(request: Request, response: Response):
 )
 async def get_pipeline(request: Request):
     run_manager: Manager = request.app.state.manager
+    if run_manager.pipeline_state == pipeline_schemas.PipelineState.load_failed:
+        raise Exception("Pipeline was never loaded")
+
     input_variables: t.List[pipeline_schemas.IOVariable] = []
     output_variables: t.List[pipeline_schemas.IOVariable] = []
+
     graph: Graph = run_manager.pipeline
     for variable in graph.variables:
         if variable.is_input:

--- a/pipeline/container/routes/v4/runs.py
+++ b/pipeline/container/routes/v4/runs.py
@@ -50,14 +50,25 @@ async def run(
                     message="Pipeline is still loading",
                 ),
             )
-
-        if manager.pipeline_state == pipeline_schemas.PipelineState.failed:
+        
+        if manager.pipeline_state == pipeline_schemas.PipelineState.load_failed:
             logger.info("Pipeline failed to load")
             return run_schemas.ContainerRunResult(
                 outputs=None,
                 error=run_schemas.ContainerRunError(
-                    type=run_schemas.ContainerRunErrorType.startup_error,
+                    type=run_schemas.ContainerRunErrorType.load_error,
                     message="Pipeline failed to load",
+                    traceback=manager.pipeline_state_message,
+                ),
+            )
+
+        if manager.pipeline_state == pipeline_schemas.PipelineState.failed:
+            logger.info("Pipeline failed to startup")
+            return run_schemas.ContainerRunResult(
+                outputs=None,
+                error=run_schemas.ContainerRunError(
+                    type=run_schemas.ContainerRunErrorType.startup_error,
+                    message="Pipeline failed to startup",
                     traceback=manager.pipeline_state_message,
                 ),
             )

--- a/pipeline/container/routes/v4/runs.py
+++ b/pipeline/container/routes/v4/runs.py
@@ -62,7 +62,7 @@ async def run(
                 ),
             )
 
-        if manager.pipeline_state == pipeline_schemas.PipelineState.failed:
+        if manager.pipeline_state == pipeline_schemas.PipelineState.startup_failed:
             logger.info("Pipeline failed to startup")
             return run_schemas.ContainerRunResult(
                 outputs=None,

--- a/pipeline/container/routes/v4/runs.py
+++ b/pipeline/container/routes/v4/runs.py
@@ -50,7 +50,7 @@ async def run(
                     message="Pipeline is still loading",
                 ),
             )
-        
+
         if manager.pipeline_state == pipeline_schemas.PipelineState.load_failed:
             logger.info("Pipeline failed to load")
             return run_schemas.ContainerRunResult(

--- a/pipeline/container/routes/v4/runs.py
+++ b/pipeline/container/routes/v4/runs.py
@@ -56,7 +56,7 @@ async def run(
             return run_schemas.ContainerRunResult(
                 outputs=None,
                 error=run_schemas.ContainerRunError(
-                    type=run_schemas.ContainerRunErrorType.load_error,
+                    type=run_schemas.ContainerRunErrorType.startup_error,
                     message="Pipeline failed to load",
                     traceback=manager.pipeline_state_message,
                 ),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pipeline-ai"
-version = "2.0.7"
+version = "2.0.8"
 description = "Pipelines for machine learning workloads."
 authors = [
   "Paul Hetherington <ph@mystic.ai>",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pipeline-ai"
-version = "2.0.9"
+version = "2.0.10"
 description = "Pipelines for machine learning workloads."
 authors = [
   "Paul Hetherington <ph@mystic.ai>",


### PR DESCRIPTION
Fills a gap in our handling of pipeline loading errors, previously we handled failed startups nicely by allowing the pipeline to run but returning a 500 for state. Similarly runs would automatically be redirected with a failed run.

We simply implement a similar idea but for the __init__ of the pipeline. This gives us the following for different cases:

Pipeline failed to load:
```
curl -X POST http://localhost:5005/v4/runs -H 'Authorization: Bearer token' \                                                                        [15:33:08]
--data '{"pipeline": "pipeline_bb16e2b2008a4acab147bfe275608ebc", "inputs": [{"type": "integer", "value": 5}], "async_run": false}' \
--header 'Content-Type: application/json' \

{"inputs":null,"outputs":null,"error":{"type":"startup_error","message":"Pipeline failed to load","traceback":"Traceback (most recent call last):\n  File \"/usr/local/lib/python3.10/site-packages/pipeline/container/manager.py\", line 53, in __init__\n    self.pipeline_module = importlib.import_module(self.pipeline_module_str)\n  File \"/usr/local/lib/python3.10/importlib/__init__.py\", line 126, in import_module\n    return _bootstrap._gcd_import(name[level:], package, level)\n  File \"<frozen importlib._bootstrap>\", line 1050, in _gcd_import\n  File \"<frozen importlib._bootstrap>\", line 1027, in _find_and_load\n  File \"<frozen importlib._bootstrap>\", line 1006, in _find_and_load_unlocked\n  File \"<frozen importlib._bootstrap>\", line 688, in _load_unlocked\n  File \"<frozen importlib._bootstrap_external>\", line 883, in exec_module\n  File \"<frozen importlib._bootstrap>\", line 241, in _call_with_frames_removed\n  File \"/app/new_pipeline.py\", line 38, in <module>\n    output_var = my_model.pedict(input_var)\nAttributeError: 'MyModelClass' object has no attribute 'pedict'. Did you mean: 'predict'?\n"},"id":"run_1a900d9ad71b4c38850a56784074253b","created_at":1706628804.568872,"updated_at":1706628804.568872,"pipeline_id":"pipeline_bb16e2b2008a4acab147bfe275608ebc","state":"failed"}%   
```

Startup failure:
```
ubuntu:test-pl/ (main✗) $ curl -X POST http://localhost:5005/v4/runs -H 'Authorization: Bearer token' \                                                                        [15:34:25]
--data '{"pipeline": "pipeline_401108dded7040abb34d91dfd1e7fe2c", "inputs": [{"type": "integer", "value": 5}], "async_run": false}' \
--header 'Content-Type: application/json' \

{"inputs":null,"outputs":null,"error":{"type":"startup_error","message":"Pipeline failed to startup","traceback":"Traceback (most recent call last):\n  File \"/usr/local/lib/python3.10/site-packages/pipeline/container/manager.py\", line 84, in startup\n    self.pipeline._startup()\n  File \"/usr/local/lib/python3.10/site-packages/pipeline/objects/graph.py\", line 617, in _startup\n    node_function.function(node_function.class_instance, *function_inputs)\n  File \"/app/new_pipeline.py\", line 12, in load\n    raise Exception(\"startup died\")\nException: startup died\n"},"id":"run_a12991fe99b6471885f01980ca41d924","created_at":1706628903.616983,"updated_at":1706628903.616983,"pipeline_id":"pipeline_401108dded7040abb34d91dfd1e7fe2c","state":"failed"}%  
```

Also, have moved the loading state to the init of the pipeline. This will serve the user much better - they are less interested in whether the pipeline is loading vs starting up than whether anything is loading or starting up. This will give a bigger window in which we can make it clear that the pipeline is starting up.

In general I think we have previously differentiated the loading of the pipeline and the startup of the pipeline, but chances are users will put code in different places, sometimes they'll download weights outside the startup function etc., so we should probably treat them more as the same state, as long as users can get a stack trace they'll be able to figure out the issue.