### PR TITLE
Plutopulp/pipeline failed state info

### DIFF
--- a/pipeline/cloud/schemas/pipelines.py
+++ b/pipeline/cloud/schemas/pipelines.py
@@ -68,21 +68,6 @@ class Pipeline(BaseModel):
     extras: t.Optional[dict]
 
 
-class PipelineGet(Pipeline):
-    id: str
-
-    created_at: datetime
-    updated_at: datetime
-
-    accelerators: t.Optional[t.List[Accelerator]]
-
-    cluster: PipelineClusterConfig | None = None
-
-    extras: t.Optional[dict]
-    #: The name of the scaling configuration
-    scaling_config: str | None = None
-
-
 class PipelinePatch(BaseModel):
     input_variables: t.Optional[t.List[IOVariable]]
     output_variables: t.Optional[t.List[IOVariable]]
@@ -135,3 +120,20 @@ class PipelineScalingInfo(BaseModel):
     current_replicas: int
     desired_replicas: int
     current_pipeline_states: dict[PipelineState, int]
+
+
+class PipelineGet(Pipeline):
+    id: str
+
+    created_at: datetime
+    updated_at: datetime
+
+    accelerators: t.Optional[t.List[Accelerator]]
+
+    cluster: PipelineClusterConfig | None = None
+
+    extras: t.Optional[dict]
+    #: The name of the scaling configuration
+    scaling_config: str | None = None
+    #: Additional info attached when pipeline fails to load or startup
+    failed_state_info: t.Optional[PipelineContainerState]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pipeline-ai"
-version = "2.1.3"
+version = "2.1.4"
 description = "Pipelines for machine learning workloads."
 authors = [
   "Paul Hetherington <ph@mystic.ai>",


### PR DESCRIPTION
Add `pipeline_state_info` as optional field (non-breaking change) to pipeline get schema, to retrieve information when a pipeline fails to load or startup. 