### PR TITLE
construct url-safe url when downloading file onto container

### DIFF
--- a/pipeline/cloud/schemas/runs.py
+++ b/pipeline/cloud/schemas/runs.py
@@ -209,7 +209,7 @@ class RunResult(BaseModel):
 
 
 class RunInput(BaseModel):
-    type: str
+    type: RunIOType
     value: t.Any
     file_name: t.Optional[str]
     file_path: t.Optional[str]

--- a/pipeline/cloud/schemas/runs.py
+++ b/pipeline/cloud/schemas/runs.py
@@ -3,7 +3,7 @@ import json
 import typing as t
 from datetime import datetime
 from enum import Enum
-from urllib.parse import quote
+from urllib.parse import quote, unquote
 
 from pydantic import validator
 
@@ -213,14 +213,14 @@ class RunInput(BaseModel):
     value: t.Any
     file_name: t.Optional[str]
     file_path: t.Optional[str]
-
-    # The file URL is only populated when this schema is
-    # returned by the API, the user should never populate it
     file_url: t.Optional[str]
 
     @validator("file_url", pre=True, always=True)
     def encode_url(cls, v):
         if v is not None:
+            # Check if the URL is already encoded
+            if v != unquote(v):
+                return v  # Return as is if already encoded
             return quote(v, safe="/:")
         return v
 

--- a/pipeline/cloud/schemas/runs.py
+++ b/pipeline/cloud/schemas/runs.py
@@ -228,8 +228,10 @@ class RunInput(BaseModel):
     @validator("file_url", pre=True, always=True)
     def encode_url(cls, v):
         if v is not None:
+            # check whether has already been encoded, to avoid
+            # multiple encoding
             if v != unquote(v):
-                return v  # Return as is if already encoded
+                return v
             return quote(v, safe="/:")
         return v
 
@@ -239,7 +241,7 @@ class RunInput(BaseModel):
             for key, val in value.items():
                 if key == "file_url" and isinstance(val, str):
                     value[key] = RunInput.encode_url(val)
-                elif isinstance(val, (dict, list)):
+                elif isinstance(val, dict):
                     RunInput.encode_nested_urls(val)
         elif isinstance(value, list):
             for item in value:

--- a/pipeline/cloud/schemas/runs.py
+++ b/pipeline/cloud/schemas/runs.py
@@ -3,6 +3,9 @@ import json
 import typing as t
 from datetime import datetime
 from enum import Enum
+from urllib.parse import quote
+
+from pydantic import validator
 
 from pipeline.cloud.schemas import BaseModel
 
@@ -208,12 +211,18 @@ class RunResult(BaseModel):
 class RunInput(BaseModel):
     type: RunIOType
     value: t.Any
-
     file_name: t.Optional[str]
     file_path: t.Optional[str]
+
     # The file URL is only populated when this schema is
     # returned by the API, the user should never populate it
     file_url: t.Optional[str]
+
+    @validator("file_url", pre=True, always=True)
+    def encode_url(cls, v):
+        if v is not None:
+            return quote(v, safe="/:")
+        return v
 
 
 class ContainerRunErrorType(str, Enum):

--- a/pipeline/cloud/schemas/runs.py
+++ b/pipeline/cloud/schemas/runs.py
@@ -233,8 +233,8 @@ class RunInput(BaseModel):
     def encode_nested_urls(cls, value):
         if isinstance(value, dict):
             for key, val in value.items():
-                if isinstance(val, cls):
-                    val.file_url = cls.encode_url(val.file_url)
+                if key == "file_url":
+                    setattr(value, key, cls.encode_url(val.file_url))
                 elif isinstance(val, dict):
                     cls.encode_nested_urls(val)
         return value

--- a/pipeline/container/manager.py
+++ b/pipeline/container/manager.py
@@ -115,7 +115,7 @@ class Manager:
 
         if hasattr(file, "url") and file.url is not None:
             # Encode the URL to handle spaces and other non-URL-safe characters
-            encoded_url = run_schemas.RunInput.encode_url(file.url.geturl(), safe="/:")
+            encoded_url = run_schemas.RunInput.encode_url(file.url.geturl())
             cache_name = hashlib.md5(file.url.geturl().encode()).hexdigest()
 
             file_name = file.url.geturl().split("/")[-1]

--- a/pipeline/container/manager.py
+++ b/pipeline/container/manager.py
@@ -8,7 +8,7 @@ from http.client import InvalidURL
 from pathlib import Path
 from types import NoneType, UnionType
 from urllib import request
-from urllib.parse import quote, urlparse
+from urllib.parse import urlparse
 
 from loguru import logger
 

--- a/pipeline/container/manager.py
+++ b/pipeline/container/manager.py
@@ -115,7 +115,7 @@ class Manager:
 
         if hasattr(file, "url") and file.url is not None:
             # Encode the URL to handle spaces and other non-URL-safe characters
-            encoded_url = quote(file.url.geturl(), safe="/:")
+            encoded_url = run_schemas.RunInput.encode_url(file.url.geturl(), safe="/:")
             cache_name = hashlib.md5(file.url.geturl().encode()).hexdigest()
 
             file_name = file.url.geturl().split("/")[-1]

--- a/pipeline/container/manager.py
+++ b/pipeline/container/manager.py
@@ -4,10 +4,11 @@ import os
 import traceback
 import typing as t
 import urllib.parse
+from http.client import InvalidURL
 from pathlib import Path
 from types import NoneType, UnionType
 from urllib import request
-from urllib.parse import urlparse
+from urllib.parse import quote, urlparse
 
 from loguru import logger
 
@@ -113,14 +114,22 @@ class Manager:
         local_host_dir = "/tmp"
 
         if hasattr(file, "url") and file.url is not None:
+            # Encode the URL to handle spaces and other non-URL-safe characters
+            encoded_url = quote(file.url.geturl(), safe="/:")
             cache_name = hashlib.md5(file.url.geturl().encode()).hexdigest()
 
             file_name = file.url.geturl().split("/")[-1]
             local_path = f"{local_host_dir}/{cache_name}/{file_name}"
             file_path = Path(local_path)
             file_path.parent.mkdir(parents=True, exist_ok=True)
+            try:
+                request.urlretrieve(encoded_url, local_path)
+            # This should not be raise due to encoded_url, but including it in case
+            except InvalidURL:
+                raise Exception("The file to download has an invalid URL.")
+            except Exception:
+                raise Exception("Error downloading file.")
 
-            request.urlretrieve(file.url.geturl(), local_path)
         elif file.remote_id is not None or file.path is not None:
             local_path = Path(file.path)
             local_path.parent.mkdir(parents=True, exist_ok=True)
@@ -129,12 +138,6 @@ class Manager:
 
         if isinstance(file, Directory):
             raise NotImplementedError("Remote ID not implemented yet")
-
-            # file.path = Path(f"{local_host_dir}/{cache_name}_dir")
-
-            # with zipfile.ZipFile(local_path, "r") as zip_ref:
-            #     zip_ref.extractall(str(file.path))
-            # return
 
         file.path = Path(local_path)
 

--- a/pipeline/container/manager.py
+++ b/pipeline/container/manager.py
@@ -123,6 +123,7 @@ class Manager:
             file_path = Path(local_path)
             file_path.parent.mkdir(parents=True, exist_ok=True)
             try:
+                # Use the encoded URL for retrieving the file
                 request.urlretrieve(encoded_url, local_path)
             # This should not be raise due to encoded_url, but including it in case
             except InvalidURL:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pipeline-ai"
-version = "2.1.7"
+version = "2.1.8"
 description = "Pipelines for machine learning workloads."
 authors = [
   "Paul Hetherington <ph@mystic.ai>",

--- a/tests/schemas/test_run_input.py
+++ b/tests/schemas/test_run_input.py
@@ -100,7 +100,7 @@ def test_mixed_content_encoding():
     ), "Mixed content URL file_5 should be encoded correctly"
 
 
-def test_run_input_list():
+def test_json_run_input_list():
     input_list = [
         {
             "type": "file",
@@ -136,7 +136,6 @@ def test_run_input_list():
             # Create RunInput instance with the modified value
             run_inputs.append(RunInput(type=item["type"], value=modified_value))
 
-    # Check the encoding of URLs
     assert (
         run_inputs[0].file_url
         == "https://storage.googleapis.com/catalyst-v4/pipeline_files/6f/d2/image%200.jpeg"  # noqa

--- a/tests/schemas/test_run_input.py
+++ b/tests/schemas/test_run_input.py
@@ -1,5 +1,4 @@
 from pipeline.cloud.schemas.runs import RunInput, RunIOType
-from urllib.parse import quote
 
 
 def test_url_with_spaces():
@@ -100,12 +99,13 @@ def test_mixed_content_encoding():
         == "http://example.com/another%20file%20with%20space.png"
     ), "Mixed content URL file_5 should be encoded correctly"
 
-def test_nested_url_encoding():
+
+def test_run_input_list():
     input_list = [
         {
             "type": "file",
             "value": None,
-            "file_url": "https://storage.googleapis.com/catalyst-staging-v4/pipeline_files/6f/d2/image 0.jpeg"
+            "file_url": "https://storage.googleapis.com/catalyst-v4/pipeline_files/6f/d2/image 0.jpeg",  # noqa
         },
         {
             "type": "dictionary",
@@ -113,29 +113,39 @@ def test_nested_url_encoding():
                 "file_1": {
                     "type": "file",
                     "value": None,
-                    "file_url": "https://storage.googleapis.com/catalyst-staging-v4/pipeline_files/d4/99/image 0.jpeg"
+                    "file_url": "https://storage.googleapis.com/catalyst-v4/pipeline_files/d4/99/image 0.jpeg",  # noqa
                 },
                 "file_2": {
                     "type": "file",
                     "value": None,
-                    "file_url": "https://storage.googleapis.com/catalyst-staging-v4/pipeline_files/c7/81/image 0.jpeg"
-                }
-            }
-        }
+                    "file_url": "https://storage.googleapis.com/catalyst-v4/pipeline_files/c7/81/image 0.jpeg",  # noqa
+                },
+            },
+        },
     ]
 
     # Convert dictionaries to RunInput instances
     run_inputs = []
     for item in input_list:
-        if 'file_url' in item:
+        if "file_url" in item:
             run_inputs.append(RunInput(**item))
         else:
-            # Create a new dictionary for the value field where each sub-item is converted to RunInput
-            modified_value = {k: RunInput(**v) for k, v in item['value'].items()}
+            # Create a new dictionary for the value field where each sub-item
+            # is converted to RunInput
+            modified_value = {k: RunInput(**v) for k, v in item["value"].items()}
             # Create RunInput instance with the modified value
-            run_inputs.append(RunInput(type=item['type'], value=modified_value))
+            run_inputs.append(RunInput(type=item["type"], value=modified_value))
 
     # Check the encoding of URLs
-    assert run_inputs[0].file_url == "https://storage.googleapis.com/catalyst-staging-v4/pipeline_files/6f/d2/image%200.jpeg", "Top-level URL should be encoded correctly"
-    assert run_inputs[1].value['file_1'].file_url == "https://storage.googleapis.com/catalyst-staging-v4/pipeline_files/d4/99/image%200.jpeg", "Nested URL file_1 should be encoded correctly"
-    assert run_inputs[1].value['file_2'].file_url == "https://storage.googleapis.com/catalyst-staging-v4/pipeline_files/c7/81/image%200.jpeg", "Nested URL file_2 should be encoded correctly"
+    assert (
+        run_inputs[0].file_url
+        == "https://storage.googleapis.com/catalyst-v4/pipeline_files/6f/d2/image%200.jpeg"  # noqa
+    ), "Top-level URL should be encoded correctly"
+    assert (
+        run_inputs[1].value["file_1"].file_url
+        == "https://storage.googleapis.com/catalyst-v4/pipeline_files/d4/99/image%200.jpeg"  # noqa
+    ), "Nested URL file_1 should be encoded correctly"
+    assert (
+        run_inputs[1].value["file_2"].file_url
+        == "https://storage.googleapis.com/catalyst-v4/pipeline_files/c7/81/image%200.jpeg"  # noqa
+    ), "Nested URL file_2 should be encoded correctly"

--- a/tests/schemas/test_run_input.py
+++ b/tests/schemas/test_run_input.py
@@ -4,11 +4,17 @@ from pipeline.cloud.schemas.runs import RunInput, RunIOType
 def test_url_with_spaces():
     url_with_spaces = "http://example.com/some file.png"
     expected_url = "http://example.com/some%20file.png"
-    run_input = RunInput(file_url=url_with_spaces, type=RunIOType.file)
+    # First instance of RunInput
+    run_input1 = RunInput(file_url=url_with_spaces, type=RunIOType.file)
     assert (
-        run_input.file_url == expected_url
-    ), "URL with spaces should be encoded correctly"
+        run_input1.file_url == expected_url
+    ), "URL with spaces should be encoded correctly in the first instance"
 
+    # Second instance of RunInput using the file_url from the first instance
+    run_input2 = RunInput(file_url=run_input1.file_url, type=RunIOType.file)
+    assert (
+        run_input2.file_url == expected_url
+    ), "URL with spaces should be encoded correctly in the second instance"
 
 def test_url_without_spaces():
     url_without_spaces = "http://example.com/file.png"

--- a/tests/schemas/test_run_input.py
+++ b/tests/schemas/test_run_input.py
@@ -1,0 +1,23 @@
+from pipeline.cloud.schemas.runs import RunInput, RunIOType
+
+
+def test_url_with_spaces():
+    url_with_spaces = "http://example.com/some file.png"
+    expected_url = "http://example.com/some%20file.png"
+    run_input = RunInput(file_url=url_with_spaces, type=RunIOType.file)
+    assert (
+        run_input.file_url == expected_url
+    ), "URL with spaces should be encoded correctly"
+
+
+def test_url_without_spaces():
+    url_without_spaces = "http://example.com/file.png"
+    run_input = RunInput(file_url=url_without_spaces, type=RunIOType.file)
+    assert (
+        run_input.file_url == url_without_spaces
+    ), "URL without spaces should not be altered"
+
+
+def test_none_url():
+    run_input = RunInput(file_url=None, type=RunIOType.file)
+    assert run_input.file_url is None, "None URL should remain None"

--- a/tests/schemas/test_run_input.py
+++ b/tests/schemas/test_run_input.py
@@ -16,6 +16,7 @@ def test_url_with_spaces():
         run_input2.file_url == expected_url
     ), "URL with spaces should be encoded correctly in the second instance"
 
+
 def test_url_without_spaces():
     url_without_spaces = "http://example.com/file.png"
     run_input = RunInput(file_url=url_without_spaces, type=RunIOType.file)
@@ -27,3 +28,73 @@ def test_url_without_spaces():
 def test_none_url():
     run_input = RunInput(file_url=None, type=RunIOType.file)
     assert run_input.file_url is None, "None URL should remain None"
+
+
+def test_nested_run_input_encoding():
+    nested_input = {
+        "type": "dictionary",
+        "value": {
+            "file_1": RunInput(
+                type="file", file_url="http://example.com/some file.png"
+            ),
+            "file_2": RunInput(
+                type="file", file_url="http://example.com/another file.png"
+            ),
+        },
+        "file_url": None,
+    }
+    run_input = RunInput(**nested_input)
+    assert (
+        run_input.value["file_1"].file_url == "http://example.com/some%20file.png"
+    ), "Nested URL file_1 should be encoded correctly"
+    assert (
+        run_input.value["file_2"].file_url == "http://example.com/another%20file.png"
+    ), "Nested URL file_2 should be encoded correctly"
+
+
+def test_deeply_nested_run_input_encoding():
+    deeply_nested_input = {
+        "type": "dictionary",
+        "value": {
+            "level_1": {
+                "level_2": {
+                    "file_3": RunInput(
+                        type="file", file_url="http://example.com/yet another file.png"
+                    )
+                }
+            }
+        },
+        "file_url": None,
+    }
+    run_input = RunInput(**deeply_nested_input)
+    assert (
+        run_input.value["level_1"]["level_2"]["file_3"].file_url
+        == "http://example.com/yet%20another%20file.png"
+    ), "Deeply nested URL should be encoded correctly"
+
+
+def test_mixed_content_encoding():
+    mixed_content_input = {
+        "type": "dictionary",
+        "value": {
+            "file_4": RunInput(
+                type="file", file_url="http://example.com/file with space.png"
+            ),
+            "non_file_data": {
+                "file_5": RunInput(
+                    type="file",
+                    file_url="http://example.com/another file with space.png",
+                )
+            },
+        },
+        "file_url": None,
+    }
+    run_input = RunInput(**mixed_content_input)
+    assert (
+        run_input.value["file_4"].file_url
+        == "http://example.com/file%20with%20space.png"
+    ), "Mixed content URL file_4 should be encoded correctly"
+    assert (
+        run_input.value["non_file_data"]["file_5"].file_url
+        == "http://example.com/another%20file%20with%20space.png"
+    ), "Mixed content URL file_5 should be encoded correctly"


### PR DESCRIPTION
When downloading a file onto the container, we safe-encode the url before downloading the file, e.g. white spaces and other special chars will be encoded etc..
Also, to ensure backward compatibility (for pipelines using older pipeline-ai versions) and to encode any file_urls at the API entry level, we update the RunInput schema to recursively encode any file_url nested within. Note also we ensure that urls are not encoded multiple times.