### PR TITLE
Reduce Docker image size by excluding pip cache dir

### DIFF
--- a/pipeline/container/docker_templates/dockerfile_template.txt
+++ b/pipeline/container/docker_templates/dockerfile_template.txt
@@ -4,17 +4,17 @@ FROM python:{python_version}-slim
 WORKDIR /app
 
 RUN apt update -y
-RUN pip install -U pip setuptools wheel
+RUN pip install --no-cache-dir -U pip setuptools wheel
 
 # Install serving packages
-RUN pip install -U fastapi==0.105.0 uvicorn==0.25.0 \
+RUN pip install --no-cache-dir -U fastapi==0.105.0 uvicorn==0.25.0 \
     python-multipart==0.0.6 loguru==0.7.2
 
 # Container commands
 {container_commands}
 
 # Install python dependencies
-RUN pip install {python_requirements}
+RUN pip install --no-cache-dir {python_requirements}
 
 # Copy in files
 COPY ./ ./

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pipeline-ai"
-version = "2.1.15"
+version = "2.2.0"
 description = "Pipelines for machine learning workloads."
 authors = [
   "Paul Hetherington <ph@mystic.ai>",


### PR DESCRIPTION
# Pull request outline

We can reduce the resultant pipeline Docker image size by specifying the `--no-cache-dir` option when running `pip install`. When testing locally, this can significantly reduce Docker image sizes (for example it reduces a Stable Diffusion image by almost 3GB). This should lead to faster cold start times.


## Checklist:
- [x] Version bumped