### PR TITLE
Increase Docker client timeout when pushing images

### DIFF
--- a/pipeline/console/container/push.py
+++ b/pipeline/console/container/push.py
@@ -84,7 +84,7 @@ def push_container(namespace: Namespace):
         else pipeline_config.pipeline_name
     )
 
-    docker_client: docker.DockerClient = docker.from_env(timeout=300)
+    docker_client: docker.DockerClient = docker.from_env(timeout=600)
 
     registry_info = http.get(endpoint="/v4/registry")
     registry_info = registry_schemas.RegistryInformation.parse_raw(registry_info.text)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pipeline-ai"
-version = "2.3.1"
+version = "2.3.2"
 description = "Pipelines for machine learning workloads."
 authors = [
   "Paul Hetherington <ph@mystic.ai>",


### PR DESCRIPTION
# Pull request outline

When pushing large image layers we sometimes get a read timeout from the Docker client. Hopefully increasing the current timeout will help.

## Checklist:

- [x] Version bumped
