### PR TITLE
Single Layer Turbo Validation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pipeline-ai"
-version = "2.4.0"
+version = "2.4.1"
 description = "Pipelines for machine learning workloads."
 authors = [
   "Paul Hetherington <ph@mystic.ai>",


### PR DESCRIPTION
Adds checks for building and pushing turbo registry images. 

Images are required to be a single layer, customer UX will be improved if we catch these client side and direct them to support.