### PR TITLE
pass turbo_registry flag on pipeline start upload

### DIFF
--- a/pipeline/cloud/schemas/pipelines.py
+++ b/pipeline/cloud/schemas/pipelines.py
@@ -34,6 +34,7 @@ class PipelineStartUpload(BaseModel):
     pipeline_name: str
     pipeline_tag: t.Optional[str]
     cluster: PipelineClusterConfig | None = None
+    turbo_registry: bool = False
 
 
 class PipelineStartUploadResponse(BaseModel):

--- a/pipeline/console/container/push.py
+++ b/pipeline/console/container/push.py
@@ -124,6 +124,7 @@ def push_container(namespace: Namespace):
                 pipeline_name=pipeline_name,
                 pipeline_tag=None,
                 cluster=pipeline_config.cluster,
+                turbo_registry=True if turbo_registry else False,
             ).dict(),
         )
         start_upload_dict = start_upload_response.json()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pipeline-ai"
-version = "2.4.4"
+version = "2.4.5"
 description = "Pipelines for machine learning workloads."
 authors = [
   "Paul Hetherington <ph@mystic.ai>",


### PR DESCRIPTION
Before pushing container to registry, pass `turbo_registry` flag to `start-upload` endpoint for validation.
