### PR TITLE
Publish current run from `v4/container/state` endpoint

### DIFF
--- a/pipeline/cloud/schemas/pipelines.py
+++ b/pipeline/cloud/schemas/pipelines.py
@@ -120,7 +120,7 @@ class PipelineState(str, Enum):
 class PipelineContainerState(BaseModel):
     state: PipelineState
     message: str | None
-    current_run_id: str | None
+    current_run: str | None
 
 
 class PipelineScalingInfo(BaseModel):

--- a/pipeline/cloud/schemas/pipelines.py
+++ b/pipeline/cloud/schemas/pipelines.py
@@ -119,7 +119,8 @@ class PipelineState(str, Enum):
 
 class PipelineContainerState(BaseModel):
     state: PipelineState
-    message: t.Optional[str]
+    message: str | None
+    current_run_id: str | None
 
 
 class PipelineScalingInfo(BaseModel):

--- a/pipeline/container/manager.py
+++ b/pipeline/container/manager.py
@@ -37,7 +37,7 @@ class Manager:
             pipeline_schemas.PipelineState.not_loaded
         )
         self.pipeline_state_message: str | None = None
-        self.current_run_id: str | None = None
+        self.current_run: str | None = None
         try:
             self._load(pipeline_path)
         except Exception:
@@ -243,7 +243,7 @@ class Manager:
     ) -> t.Any:
         with logger.contextualize(run_id=run_id):
             logger.info("Running pipeline")
-            self.current_run_id = run_id
+            self.current_run = run_id
             try:
                 args = self._parse_inputs(input_data, self.pipeline)
                 result = self.pipeline.run(*args)
@@ -252,6 +252,6 @@ class Manager:
             except Exception as exc:
                 raise RunnableError(exception=exc, traceback=traceback.format_exc())
             finally:
-                self.current_run_id = None
+                self.current_run = None
             logger.info("Run successful")
             return result

--- a/pipeline/container/manager.py
+++ b/pipeline/container/manager.py
@@ -98,7 +98,7 @@ class Manager:
                 self.pipeline._startup()
             except Exception:
                 tb = traceback.format_exc()
-                logger.exception("Exception raised during pipeline execution")
+                logger.exception("Exception raised during pipeline startup")
                 self.pipeline_state = pipeline_schemas.PipelineState.startup_failed
                 self.pipeline_state_message = tb
             else:

--- a/pipeline/container/manager.py
+++ b/pipeline/container/manager.py
@@ -32,6 +32,21 @@ def _get_url_or_path(input_schema: run_schemas.RunInput) -> str | None:
 
 
 class Manager:
+    def __init__(self, pipeline_path: str):
+        self.pipeline_state: pipeline_schemas.PipelineState = (
+            pipeline_schemas.PipelineState.not_loaded
+        )
+        self.pipeline_state_message: str | None = None
+        self.current_run_id: str | None = None
+        try:
+            self._load(pipeline_path)
+        except Exception:
+            tb = traceback.format_exc()
+            logger.exception("Exception raised when loading pipeline")
+            self.pipeline_state = pipeline_schemas.PipelineState.load_failed
+            self.pipeline_state_message = tb
+            return
+
     def _load(self, pipeline_path: str):
         with logger.contextualize(pipeline_stage="loading"):
             logger.info("Loading pipeline")
@@ -73,20 +88,6 @@ class Manager:
             self.pipeline_image = os.environ.get("PIPELINE_IMAGE", "unknown")
 
             logger.info(f"Pipeline set to {self.pipeline_path}")
-
-    def __init__(self, pipeline_path: str):
-        self.pipeline_state: pipeline_schemas.PipelineState = (
-            pipeline_schemas.PipelineState.not_loaded
-        )
-        self.pipeline_state_message: str | None = None
-        try:
-            self._load(pipeline_path)
-        except Exception:
-            tb = traceback.format_exc()
-            logger.exception("Exception raised when loading pipeline")
-            self.pipeline_state = pipeline_schemas.PipelineState.load_failed
-            self.pipeline_state_message = tb
-            return
 
     def startup(self):
         if self.pipeline_state == pipeline_schemas.PipelineState.load_failed:
@@ -242,12 +243,15 @@ class Manager:
     ) -> t.Any:
         with logger.contextualize(run_id=run_id):
             logger.info("Running pipeline")
-            args = self._parse_inputs(input_data, self.pipeline)
+            self.current_run_id = run_id
             try:
+                args = self._parse_inputs(input_data, self.pipeline)
                 result = self.pipeline.run(*args)
             except RunInputException:
                 raise
             except Exception as exc:
                 raise RunnableError(exception=exc, traceback=traceback.format_exc())
+            finally:
+                self.current_run_id = None
             logger.info("Run successful")
             return result

--- a/pipeline/container/routes/v4/container.py
+++ b/pipeline/container/routes/v4/container.py
@@ -42,7 +42,7 @@ async def is_ready(request: Request, response: Response):
     return pipeline_schemas.PipelineContainerState(
         state=run_manager.pipeline_state,
         message=run_manager.pipeline_state_message,
-        current_run_id=run_manager.current_run_id,
+        current_run=run_manager.current_run,
     )
 
 

--- a/pipeline/container/routes/v4/container.py
+++ b/pipeline/container/routes/v4/container.py
@@ -27,7 +27,7 @@ router = APIRouter(prefix="/container")
     },
 )
 async def is_ready(request: Request, response: Response):
-    run_manager = request.app.state.manager
+    run_manager: Manager = request.app.state.manager
     if run_manager.pipeline_state in [
         pipeline_schemas.PipelineState.loading,
         pipeline_schemas.PipelineState.not_loaded,
@@ -42,6 +42,7 @@ async def is_ready(request: Request, response: Response):
     return pipeline_schemas.PipelineContainerState(
         state=run_manager.pipeline_state,
         message=run_manager.pipeline_state_message,
+        current_run_id=run_manager.current_run_id,
     )
 
 

--- a/pipeline/container/routes/v4/runs.py
+++ b/pipeline/container/routes/v4/runs.py
@@ -1,10 +1,5 @@
 import asyncio
-import io
-import os
-import shutil
 import traceback
-import uuid
-from pathlib import Path
 
 from fastapi import APIRouter, Request, Response
 from loguru import logger
@@ -13,8 +8,7 @@ from pipeline.cloud.http import StreamingResponseWithStatusCode
 from pipeline.cloud.schemas import pipelines as pipeline_schemas
 from pipeline.cloud.schemas import runs as run_schemas
 from pipeline.container.manager import Manager
-from pipeline.exceptions import RunInputException, RunnableError
-from pipeline.objects.graph import File
+from pipeline.exceptions import RunnableError
 
 router = APIRouter(prefix="/runs", tags=["runs"])
 
@@ -45,12 +39,11 @@ async def run(
             return result
 
         execution_queue: asyncio.Queue = request.app.state.execution_queue
-
         response_queue: asyncio.Queue = asyncio.Queue()
         execution_queue.put_nowait((run_create, response_queue))
-        run_output = await response_queue.get()
+
+        response_schema, response.status_code = await response_queue.get()
         logger.info("Returning run result")
-        response_schema, response.status_code = _generate_run_result(run_output)
         return response_schema
 
 
@@ -83,9 +76,8 @@ async def stream_run(
 
         response_queue: asyncio.Queue = asyncio.Queue()
         execution_queue.put_nowait((run_create, response_queue))
-        run_output = await response_queue.get()
-
-        response_schema, response.status_code = _generate_run_result(run_output)
+        # wait for result
+        response_schema, response.status_code = await response_queue.get()
 
         outputs = response_schema.outputs or []
         if not outputs:
@@ -239,131 +231,3 @@ def _handle_pipeline_state_not_ready(
                 traceback=manager.pipeline_state_message,
             ),
         )
-
-
-def _generate_run_result(run_output) -> tuple[run_schemas.ContainerRunResult, int]:
-    if isinstance(run_output, RunInputException):
-        return (
-            run_schemas.ContainerRunResult(
-                outputs=None,
-                inputs=None,
-                error=run_schemas.ContainerRunError(
-                    type=run_schemas.ContainerRunErrorType.input_error,
-                    message=run_output.message,
-                    traceback=None,
-                ),
-            ),
-            400,
-        )
-    elif isinstance(run_output, RunnableError):
-        return (
-            run_schemas.ContainerRunResult(
-                outputs=None,
-                inputs=None,
-                error=run_schemas.ContainerRunError(
-                    type=run_schemas.ContainerRunErrorType.pipeline_error,
-                    message=repr(run_output.exception),
-                    traceback=run_output.traceback,
-                ),
-            ),
-            200,
-        )
-    elif isinstance(run_output, Exception):
-        return (
-            run_schemas.ContainerRunResult(
-                outputs=None,
-                inputs=None,
-                error=run_schemas.ContainerRunError(
-                    type=run_schemas.ContainerRunErrorType.unknown,
-                    message=str(run_output),
-                    traceback=None,
-                ),
-            ),
-            500,
-        )
-    else:
-        outputs = _parse_run_outputs(run_output)
-        return (
-            run_schemas.ContainerRunResult(
-                outputs=outputs,
-                error=None,
-                inputs=None,
-            ),
-            200,
-        )
-
-
-def _parse_run_outputs(run_outputs):
-    outputs = []
-    for output in run_outputs:
-        output_type = run_schemas.RunIOType.from_object(output)
-        # if single file
-        if output_type == run_schemas.RunIOType.file:
-            file_schema = _save_run_file(output)
-            outputs.append(
-                run_schemas.RunOutput(type=output_type, value=None, file=file_schema)
-            )
-        # else if list of files
-        elif (
-            output_type == run_schemas.RunIOType.pkl
-            and isinstance(output, list)
-            and all([isinstance(item, (File, io.BufferedIOBase)) for item in output])
-        ):
-            file_list = []
-            for file in output:
-                file_schema = _save_run_file(file)
-                file_list.append(
-                    run_schemas.RunOutput(
-                        type=run_schemas.RunIOType.file,
-                        value=None,
-                        file=file_schema,
-                    )
-                )
-            outputs.append(
-                run_schemas.RunOutput(
-                    type=run_schemas.RunIOType.array,
-                    value=file_list,
-                    file=None,
-                )
-            )
-        else:
-            outputs.append(
-                run_schemas.RunOutput(type=output_type, value=output, file=None)
-            )
-    return outputs
-
-
-def _save_run_file(file: File | io.BufferedIOBase) -> run_schemas.RunOutputFile:
-    # ensure we save the file somewhere unique on the file system so it doesn't
-    # get overwritten by another run
-    uuid_path = str(uuid.uuid4())
-    output_path = Path(f"/tmp/run_files/{uuid_path}")
-    output_path.mkdir(parents=True, exist_ok=True)
-
-    if isinstance(file, File):
-        # should always exist
-        assert file.path
-        file_name = file.path.name
-        output_file = output_path / file_name
-        file_size = os.stat(file.path).st_size
-        # copy file to new output location
-        shutil.copyfile(file.path, output_file)
-    else:
-        file_name = getattr(
-            file,
-            "name",
-            str(uuid.uuid4()),
-        )
-        try:
-            file_size = file.seek(0, os.SEEK_END)
-        except Exception:
-            file_size = -1
-            logger.warning(f"Could not get size of type {type(file)}")
-        # write file to new output location
-        output_file = output_path / file_name
-        output_file.write_bytes(file.read())
-
-    file_schema = run_schemas.RunOutputFile(
-        name=file_name, path=str(output_file), size=file_size, url=None
-    )
-    return file_schema

--- a/pipeline/container/services/run.py
+++ b/pipeline/container/services/run.py
@@ -1,0 +1,167 @@
+import asyncio
+import io
+import os
+import shutil
+import uuid
+from pathlib import Path
+
+from fastapi.concurrency import run_in_threadpool
+from loguru import logger
+
+from pipeline.cloud.schemas import runs as run_schemas
+from pipeline.container.logging import redirect_stdout
+from pipeline.container.manager import Manager
+from pipeline.exceptions import RunInputException, RunnableError
+from pipeline.objects.graph import File
+
+
+async def execution_handler(execution_queue: asyncio.Queue, manager: Manager) -> None:
+    with redirect_stdout():
+        await run_in_threadpool(manager.startup)
+        while True:
+            try:
+                args, response_queue = await execution_queue.get()
+                args: run_schemas.ContainerRunCreate
+                input_data = args.inputs
+                run_id = args.run_id
+                with logger.contextualize(run_id=run_id):
+                    try:
+                        output = await run_in_threadpool(
+                            manager.run, run_id=run_id, input_data=input_data
+                        )
+                    except Exception as e:
+                        logger.exception("Exception raised during pipeline execution")
+                        output = e
+
+                    response_schema, status_code = _generate_run_result(output)
+                    response_queue.put_nowait((response_schema, status_code))
+            except Exception:
+                logger.exception("Got an error in the execution loop handler")
+
+
+def _generate_run_result(run_output) -> tuple[run_schemas.ContainerRunResult, int]:
+    if isinstance(run_output, RunInputException):
+        return (
+            run_schemas.ContainerRunResult(
+                outputs=None,
+                inputs=None,
+                error=run_schemas.ContainerRunError(
+                    type=run_schemas.ContainerRunErrorType.input_error,
+                    message=run_output.message,
+                    traceback=None,
+                ),
+            ),
+            400,
+        )
+    elif isinstance(run_output, RunnableError):
+        return (
+            run_schemas.ContainerRunResult(
+                outputs=None,
+                inputs=None,
+                error=run_schemas.ContainerRunError(
+                    type=run_schemas.ContainerRunErrorType.pipeline_error,
+                    message=repr(run_output.exception),
+                    traceback=run_output.traceback,
+                ),
+            ),
+            200,
+        )
+    elif isinstance(run_output, Exception):
+        return (
+            run_schemas.ContainerRunResult(
+                outputs=None,
+                inputs=None,
+                error=run_schemas.ContainerRunError(
+                    type=run_schemas.ContainerRunErrorType.unknown,
+                    message=str(run_output),
+                    traceback=None,
+                ),
+            ),
+            500,
+        )
+    else:
+        outputs = _parse_run_outputs(run_output)
+        return (
+            run_schemas.ContainerRunResult(
+                outputs=outputs,
+                error=None,
+                inputs=None,
+            ),
+            200,
+        )
+
+
+def _parse_run_outputs(run_outputs):
+    outputs = []
+    for output in run_outputs:
+        output_type = run_schemas.RunIOType.from_object(output)
+        # if single file
+        if output_type == run_schemas.RunIOType.file:
+            file_schema = _save_run_file(output)
+            outputs.append(
+                run_schemas.RunOutput(type=output_type, value=None, file=file_schema)
+            )
+        # else if list of files
+        elif (
+            output_type == run_schemas.RunIOType.pkl
+            and isinstance(output, list)
+            and all([isinstance(item, (File, io.BufferedIOBase)) for item in output])
+        ):
+            file_list = []
+            for file in output:
+                file_schema = _save_run_file(file)
+                file_list.append(
+                    run_schemas.RunOutput(
+                        type=run_schemas.RunIOType.file,
+                        value=None,
+                        file=file_schema,
+                    )
+                )
+            outputs.append(
+                run_schemas.RunOutput(
+                    type=run_schemas.RunIOType.array,
+                    value=file_list,
+                    file=None,
+                )
+            )
+        else:
+            outputs.append(
+                run_schemas.RunOutput(type=output_type, value=output, file=None)
+            )
+    return outputs
+
+
+def _save_run_file(file: File | io.BufferedIOBase) -> run_schemas.RunOutputFile:
+    # ensure we save the file somewhere unique on the file system so it doesn't
+    # get overwritten by another run
+    uuid_path = str(uuid.uuid4())
+    output_path = Path(f"/tmp/run_files/{uuid_path}")
+    output_path.mkdir(parents=True, exist_ok=True)
+
+    if isinstance(file, File):
+        # should always exist
+        assert file.path
+        file_name = file.path.name
+        output_file = output_path / file_name
+        file_size = os.stat(file.path).st_size
+        # copy file to new output location
+        shutil.copyfile(file.path, output_file)
+    else:
+        file_name = getattr(
+            file,
+            "name",
+            str(uuid.uuid4()),
+        )
+        try:
+            file_size = file.seek(0, os.SEEK_END)
+        except Exception:
+            file_size = -1
+            logger.warning(f"Could not get size of type {type(file)}")
+        # write file to new output location
+        output_file = output_path / file_name
+        output_file.write_bytes(file.read())
+
+    file_schema = run_schemas.RunOutputFile(
+        name=file_name, path=str(output_file), size=file_size, url=None
+    )
+    return file_schema

--- a/poetry.lock
+++ b/poetry.lock
@@ -22,6 +22,20 @@ test = ["anyio[trio]", "coverage[toml] (>=4.5)", "hypothesis (>=4.0)", "mock (>=
 trio = ["trio (<0.22)"]
 
 [[package]]
+name = "asgi-lifespan"
+version = "2.1.0"
+description = "Programmatic startup/shutdown of ASGI apps."
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "asgi-lifespan-2.1.0.tar.gz", hash = "sha256:5e2effaf0bfe39829cf2d64e7ecc47c7d86d676a6599f7afba378c31f5e3a308"},
+    {file = "asgi_lifespan-2.1.0-py3-none-any.whl", hash = "sha256:ed840706680e28428c01e14afb3875d7d76d3206f3d5b2f2294e059b5c23804f"},
+]
+
+[package.dependencies]
+sniffio = "*"
+
+[[package]]
 name = "black"
 version = "24.4.2"
 description = "The uncompromising code formatter."
@@ -1255,4 +1269,4 @@ dev = ["black (>=19.3b0)", "pytest (>=4.6.2)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "0a13da9980dd41592328a7ea5e0879a54fdebb375673d442b71431bff72543d2"
+content-hash = "7f228f89f9562db857fd4ad3d0459f23b15cb2c872dab4789faf3081480ad5b6"

--- a/poetry.lock
+++ b/poetry.lock
@@ -395,13 +395,13 @@ trio = ["trio (>=0.22.0,<0.26.0)"]
 
 [[package]]
 name = "httpx"
-version = "0.26.0"
+version = "0.27.0"
 description = "The next generation HTTP client."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "httpx-0.26.0-py3-none-any.whl", hash = "sha256:8915f5a3627c4d47b73e8202457cb28f1266982d1159bd5779d86a80c0eab1cd"},
-    {file = "httpx-0.26.0.tar.gz", hash = "sha256:451b55c30d5185ea6b23c2c793abf9bb237d2a7dfb901ced6ff69ad37ec1dfaf"},
+    {file = "httpx-0.27.0-py3-none-any.whl", hash = "sha256:71d5465162c13681bff01ad59b2cc68dd838ea1f10e51574bac27103f00c91a5"},
+    {file = "httpx-0.27.0.tar.gz", hash = "sha256:a0cb88a46f32dc874e04ee956e4c2764aba2aa228f650b06788ba6bda2962ab5"},
 ]
 
 [package.dependencies]
@@ -781,13 +781,13 @@ testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "no
 
 [[package]]
 name = "pytest-asyncio"
-version = "0.23.6"
+version = "0.23.8"
 description = "Pytest support for asyncio"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pytest-asyncio-0.23.6.tar.gz", hash = "sha256:ffe523a89c1c222598c76856e76852b787504ddb72dd5d9b6617ffa8aa2cde5f"},
-    {file = "pytest_asyncio-0.23.6-py3-none-any.whl", hash = "sha256:68516fdd1018ac57b846c9846b954f0393b26f094764a28c955eabb0536a4e8a"},
+    {file = "pytest_asyncio-0.23.8-py3-none-any.whl", hash = "sha256:50265d892689a5faefb84df80819d1ecef566eb3549cf915dfb33569359d1ce2"},
+    {file = "pytest_asyncio-0.23.8.tar.gz", hash = "sha256:759b10b33a6dc61cce40a8bd5205e302978bbbcc00e279a8b61d9a6a3c82e4d3"},
 ]
 
 [package.dependencies]
@@ -1255,4 +1255,4 @@ dev = ["black (>=19.3b0)", "pytest (>=4.6.2)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "59cf5f8d69a76b5bd4df3c7f0573a575ef08aadac8f80ca4ba4d17ef1556cd5e"
+content-hash = "0a13da9980dd41592328a7ea5e0879a54fdebb375673d442b71431bff72543d2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pipeline-ai"
-version = "2.4.7"
+version = "2.5.0"
 description = "Pipelines for machine learning workloads."
 authors = [
   "Paul Hetherington <ph@mystic.ai>",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ python-multipart = "^0.0.6"
 boto3 = "^1.34.5"
 loguru = "^0.7.2"
 pytest-asyncio = "^0.23.8"
+asgi-lifespan = "^2.1.0"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ pyhumps = "^3.8.0"
 tqdm = "^4.66.1"
 PyYAML = "^6.0"
 cloudpickle = "^2.2.0"
-httpx = "^0.26.0"
+httpx = "^0.27.0"
 tabulate = "^0.9.0"
 requests = "^2.32.3"
 requests-toolbelt = "^1.0.0"
@@ -41,7 +41,7 @@ uvicorn = "^0.25.0"
 python-multipart = "^0.0.6"
 boto3 = "^1.34.5"
 loguru = "^0.7.2"
-pytest-asyncio = "^0.23.5.post1"
+pytest-asyncio = "^0.23.8"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/tests/container/routes/conftest.py
+++ b/tests/container/routes/conftest.py
@@ -1,5 +1,8 @@
+from contextlib import asynccontextmanager
+
 import pytest
-from fastapi.testclient import TestClient
+from asgi_lifespan import LifespanManager
+from httpx import AsyncClient
 
 from pipeline.container.startup import create_app
 
@@ -11,6 +14,21 @@ async def app():
 
 
 @pytest.fixture
-async def client(app):
-    with TestClient(app) as client:
+async def get_test_client(app, monkeypatch):
+
+    @asynccontextmanager
+    async def _get_test_client(pipeline_path):
+        monkeypatch.setenv("PIPELINE_PATH", pipeline_path)
+        async with LifespanManager(app) as manager:
+            async with AsyncClient(app=manager.app, base_url="http://test") as client:
+                yield client
+
+    return _get_test_client
+
+
+@pytest.fixture
+async def client(get_test_client):
+    async with get_test_client(
+        pipeline_path="tests.container.fixtures.adder_pipeline:my_pipeline"
+    ) as client:
         yield client

--- a/tests/container/routes/conftest.py
+++ b/tests/container/routes/conftest.py
@@ -32,3 +32,12 @@ async def client(get_test_client):
         pipeline_path="tests.container.fixtures.adder_pipeline:my_pipeline"
     ) as client:
         yield client
+
+
+@pytest.fixture
+async def client_failed_pipeline(get_test_client):
+    # use invalid path to simulate pipeline failed error
+    async with get_test_client(
+        pipeline_path="tests.container.fixtures.oops:my_pipeline"
+    ) as client:
+        yield client

--- a/tests/container/routes/test_container.py
+++ b/tests/container/routes/test_container.py
@@ -9,7 +9,7 @@ async def test_is_ready(client):
     result = pipeline_schemas.PipelineContainerState.parse_obj(response.json())
     assert result.state == pipeline_schemas.PipelineState.loaded
     assert result.message is None
-    assert result.current_run_id is None
+    assert result.current_run is None
 
 
 async def test_is_ready_pipeline_load_failed(client_failed_pipeline):
@@ -20,4 +20,4 @@ async def test_is_ready_pipeline_load_failed(client_failed_pipeline):
     assert result.state == pipeline_schemas.PipelineState.load_failed
     assert result.message is not None
     assert result.message.startswith("Traceback")
-    assert result.current_run_id is None
+    assert result.current_run is None

--- a/tests/container/routes/test_container.py
+++ b/tests/container/routes/test_container.py
@@ -1,0 +1,23 @@
+from fastapi import status
+
+from pipeline.cloud.schemas import pipelines as pipeline_schemas
+
+
+async def test_is_ready(client):
+    response = await client.get("/v4/container/state")
+    assert response.status_code == status.HTTP_200_OK
+    result = pipeline_schemas.PipelineContainerState.parse_obj(response.json())
+    assert result.state == pipeline_schemas.PipelineState.loaded
+    assert result.message is None
+    assert result.current_run_id is None
+
+
+async def test_is_ready_pipeline_load_failed(client_failed_pipeline):
+    client = client_failed_pipeline
+    response = await client.get("/v4/container/state")
+    assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+    result = pipeline_schemas.PipelineContainerState.parse_obj(response.json())
+    assert result.state == pipeline_schemas.PipelineState.load_failed
+    assert result.message is not None
+    assert result.message.startswith("Traceback")
+    assert result.current_run_id is None

--- a/tests/container/routes/test_status.py
+++ b/tests/container/routes/test_status.py
@@ -2,5 +2,5 @@ from fastapi import status
 
 
 async def test_status(client):
-    response = client.get("/status")
+    response = await client.get("/status")
     assert response.status_code == status.HTTP_200_OK


### PR DESCRIPTION
# Pull request outline

As well as publishing the current run, there are a few more changes in here (looking at the commits individually will help review):
- refactor the `execution_handler` slightly
    - move into a run services module
    - it now returns the result and status code rather than just the result
- update a few dependencies (including httpx)
- update the tests
    - needed to use an async client in order to mock certain behaviour (if we don't use an async client we get issues mocking things as they run in a different event loop to the API)  


## Checklist:
- [x] Tests written
- [x] Version bumped
