### PR TITLE
Update schemas to support async runs

### DIFF
--- a/pipeline/cloud/schemas/runs.py
+++ b/pipeline/cloud/schemas/runs.py
@@ -329,3 +329,6 @@ class RunCreate(BaseModel):
     # flag to determine whether the run will wait for compute resources to be
     # become available if none are currently running the pipeline
     wait_for_resources: bool | None = None
+    # run_id is not used and should not be provided (it is kept here for
+    # backwards compatibility)
+    run_id: str | None = None

--- a/pipeline/cloud/schemas/runs.py
+++ b/pipeline/cloud/schemas/runs.py
@@ -265,14 +265,16 @@ class ContainerRunError(BaseModel):
 
 class ContainerRunCreate(BaseModel):
     # run_id is optional since it's just used for attaching logs to a run
-    run_id: t.Optional[str]
-    inputs: t.List[RunInput]
+    run_id: str | None
+    inputs: list[RunInput]
+    async_run: bool = False
+    callback_url: str | None
 
 
 class ContainerRunResult(BaseModel):
-    inputs: t.Optional[t.List[RunInput]]
-    outputs: t.Optional[t.List[RunOutput]]
-    error: t.Optional[ContainerRunError]
+    inputs: list[RunInput] | None
+    outputs: list[RunOutput] | None
+    error: ContainerRunError | None
 
     def outputs_formatted(self) -> t.List[t.Any]:
         outputs = self.outputs or []
@@ -319,9 +321,10 @@ class RunStateTransitions(BaseModel):
     data: t.List[RunStateTransition]
 
 
-class RunCreate(ContainerRunCreate):
+class RunCreate(BaseModel):
     # pipeline id or pointer
     pipeline: str
+    inputs: list[RunInput]
     async_run: bool = False
     # flag to determine whether the run will wait for compute resources to be
     # become available if none are currently running the pipeline

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pipeline-ai"
-version = "2.5.0"
+version = "2.5.1"
 description = "Pipelines for machine learning workloads."
 authors = [
   "Paul Hetherington <ph@mystic.ai>",


### PR DESCRIPTION
# Pull request outline

Here we update the run schemas to support async runs in the pipeline container (which are coming soon).

It no longer makes sense to share the run schemas across the main API and the pipeline container since several params are now specific to one or the other, so it is best to separate them to avoid confusion. For example `run_id` is an optional parameter for `ContainerRunCreate` but was inherited by `RunCreate`, even though it is not used by the main API.

Main changes here are adding `async_run` and `callback_url` to `ContainerRunCreate` - these will be needed for async runs. These are optional so shouldn't cause anything to break

I have kept `run_id` in `RunCreate` just for backwards compatibility, in case users are using this unknowingly (we can probably check in the main API if it's being used and deprecate if not)

## Checklist:
- [x] Version bumped
