### PR TITLE
Better reporting of readme generation errors

### DIFF
--- a/pipeline/console/container/push.py
+++ b/pipeline/console/container/push.py
@@ -72,11 +72,22 @@ def push_container(namespace: Namespace):
         pipeline_config.pipeline_graph.split(":")[0] + ".py"
     ).read_text()
     pipeline_code = "```python\n" + pipeline_code + "\n```"
-    pipeline_config.readme = pipeline_config.readme.format(
-        pipeline_name=pipeline_config.pipeline_name,
-        pipeline_yaml=pipeline_yaml_text,
-        pipeline_code=pipeline_code,
-    )
+    try:
+        pipeline_config.readme = pipeline_config.readme.format(
+            pipeline_name=pipeline_config.pipeline_name,
+            pipeline_yaml=pipeline_yaml_text,
+            pipeline_code=pipeline_code,
+        )
+    except KeyError as exc:
+        _print(
+            f"Failed to generate README: {exc!r}\n"
+            "You may need to escape certain characters, eg change `{ }` to `{{ }}`",
+            "ERROR",
+        )
+        return
+    except Exception as exc:
+        _print(f"Failed to generate README: {exc!r}", "ERROR")
+        raise
 
     pipeline_name = (
         pipeline_config.pipeline_name.split(":")[0]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pipeline-ai"
-version = "2.6.0"
+version = "2.6.1"
 description = "Pipelines for machine learning workloads."
 authors = [
   "Paul Hetherington <ph@mystic.ai>",


### PR DESCRIPTION
# Pull request outline

Generating the README can sometimes fail, as it is parsed as a Python template string. Here we add better reporting of errors to make it easier to resolve these.

Example of new error:
```
❯ pipeline container push
Pipeline 10:13:00 - [ERROR]: Failed to generate README: KeyError('hmm')
You may need to escape certain characters, eg change `{ }` to `{{ }}`
```


## Checklist:
- [x] Version bumped

