### PR TITLE
Increase timeout for waiting for Cog model to load

### DIFF
--- a/pipeline/container/frameworks/cog.py
+++ b/pipeline/container/frameworks/cog.py
@@ -98,7 +98,7 @@ class CogManager(Manager):
             logger.info("Pipeline started successfully")
 
     def _wait_for_cog_startup(self, until_fully_ready: bool = True):
-        max_retries = 100
+        max_retries = 150
         i = 0
         while i < max_retries:
             i += 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pipeline-ai"
-version = "2.7.1"
+version = "2.7.2"
 description = "Pipelines for machine learning workloads."
 authors = [
   "Paul Hetherington <ph@mystic.ai>",


### PR DESCRIPTION
# Pull request outline

If the Cog model is very large it can sometimes take more than 10 mins to start. So we increase the timeout to cater for this.
