### PR TITLE
Support for pydantic >= 2

### DIFF
--- a/pipeline/cloud/pipelines.py
+++ b/pipeline/cloud/pipelines.py
@@ -2,7 +2,7 @@ import io
 import os
 import typing as t
 
-from pydantic import ValidationError
+from pydantic.v1 import ValidationError
 
 from pipeline.cloud import http
 from pipeline.cloud.files import resolve_run_input_file_object

--- a/pipeline/cloud/schemas/__init__.py
+++ b/pipeline/cloud/schemas/__init__.py
@@ -2,9 +2,9 @@ import os
 from datetime import datetime, timezone
 
 import humps
-from pydantic import BaseModel as _BaseModel
-from pydantic import Extra, validator
-from pydantic.generics import GenericModel as _GenericModel
+from pydantic.v1 import BaseModel as _BaseModel
+from pydantic.v1 import Extra, validator
+from pydantic.v1.generics import GenericModel as _GenericModel
 
 CAMEL_CASE_ALIASES = bool(os.environ.get("CAMEL_CASE_ALIASES", False))
 

--- a/pipeline/cloud/schemas/cluster.py
+++ b/pipeline/cloud/schemas/cluster.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 
 
 class PipelineClusterConfig(BaseModel):

--- a/pipeline/cloud/schemas/pagination.py
+++ b/pipeline/cloud/schemas/pagination.py
@@ -2,7 +2,7 @@ import typing as t
 from enum import Enum
 from math import ceil
 
-from pydantic import conint
+from pydantic.v1 import conint
 
 from . import BaseModel, GenericModel
 

--- a/pipeline/cloud/schemas/pointers.py
+++ b/pipeline/cloud/schemas/pointers.py
@@ -1,7 +1,7 @@
 import re
 import typing as t
 
-from pydantic import validator
+from pydantic.v1 import validator
 
 from pipeline.cloud.schemas import BaseModel
 

--- a/pipeline/cloud/schemas/registry.py
+++ b/pipeline/cloud/schemas/registry.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 
 
 class RegistryInformation(BaseModel):

--- a/pipeline/cloud/schemas/runs.py
+++ b/pipeline/cloud/schemas/runs.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from enum import Enum
 from urllib.parse import quote, unquote
 
-from pydantic import root_validator, validator
+from pydantic.v1 import root_validator, validator
 
 from pipeline.cloud.schemas import BaseModel
 

--- a/pipeline/configuration/__init__.py
+++ b/pipeline/configuration/__init__.py
@@ -5,7 +5,7 @@ import typing as t
 from pathlib import Path
 
 import yaml
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 
 PIPELINE_DIR = Path(
     os.getenv(

--- a/pipeline/console/container/schemas.py
+++ b/pipeline/console/container/schemas.py
@@ -1,6 +1,6 @@
 import typing as t
 
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 
 from pipeline.cloud.compute_requirements import Accelerator
 from pipeline.cloud.schemas import cluster as cluster_schemas

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.10"
-pydantic = "^1.8.2"
+pydantic = "^2.9.2"
 pyhumps = "^3.8.0"
 tqdm = "^4.66.1"
 PyYAML = "^6.0"


### PR DESCRIPTION
### Changed all pydantic imports to `import pydantic.v1` so it can be used with pydantic >= 2.

This is important because the requirement for pydantic1 is causing problems using other packages simultaneously which use pydantic >= 2.0 in the same project/environment (which often is the case)